### PR TITLE
Use WSDL function for TestRun custom fields

### DIFF
--- a/src/pylero/custom_field_type.py
+++ b/src/pylero/custom_field_type.py
@@ -27,6 +27,7 @@ class CustomFieldType(BasePolarion):
                      "description": "description",
                      "cft_id": "id",
                      "name": "name",
+                     "multi": "multi",
                      "required": "required",
                      "type": "type",
                      "uri": "_uri",

--- a/src/pylero/enum_custom_field_type.py
+++ b/src/pylero/enum_custom_field_type.py
@@ -29,6 +29,7 @@ class EnumCustomFieldType(BasePolarion):
                      "enum_id": "enumId",
                      "cft_id": "id",
                      "name": "name",
+                     "multi": "multi",
                      "required": "required",
                      "type": "type",
                      "uri": "_uri",


### PR DESCRIPTION
Polarion now provides testmanagement.getDefinedTestRunCustomFieldTypes
function to get testrun custom fields, no need to download the xml
from repo and parse it for the custom fields.

This resolves issues:
https://github.com/RedHatQE/pylero/issues/25
https://github.com/RedHatQE/pylero/issues/23

Signed-off-by: Wayne Sun <gsun@redhat.com>