### PR TITLE
[Minor] Remove requests module usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ The install_requires attribute in setup.py installs the following requirements:
 ```
     suds; python_version < '3.0'
     suds-py3; python_version >= '3.0'
-    requests>=2.6.0
     click
     readline; python_version <= '3.6'
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 suds; python_version < '3.0'
 suds-py3; python_version >= '3.0'
-requests>=2.6.0
 click
 readline; python_version <= '3.6'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires = python-suds python-requests
+requires = python-suds

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ for scheme in list(INSTALL_SCHEMES.values()):
 install_requires_ = [
     'click',
     'pre-commit',
-    'requests>=2.6.0',
 ]
 
 if sys.version_info >= (3, 0):

--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import os
 
-import requests
 import suds
 from pylero._compatible import basestring
 from pylero._compatible import classmethod
@@ -33,12 +32,8 @@ from pylero.text import Text
 from pylero.user import User
 from pylero.work_item import _WorkItem
 from pylero.work_item import TestCase
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
 # Build is used in custom fields.
 # Plan is used in custom fields.
-
-# This is to disable the InsecureRequestWarning
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 def generate_description(test_run, test_case, test_record):
@@ -248,8 +243,6 @@ class TestRun(BasePolarion):
     _id_field = "test_run_id"
     _obj_client = "test_management_client"
     _obj_struct = "tns3:TestRun"
-    CUSTOM_FIELDS_FILE = \
-        ".polarion/testing/configuration/testrun-custom-fields.xml"
     _custom_field_cache = {}
 
     @property


### PR DESCRIPTION
After #30 we don't need requests module

```
-> rg requests -g "*.py"
src/pylero/session.py
162:            enclosing_session: the HTTP session that the requests are sent
```

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>