### PR TITLE
Issue #43 pylero-cmd to handle run id with spaces, cmd.py

### DIFF
--- a/src/pylero/cli/cmd.py
+++ b/src/pylero/cli/cmd.py
@@ -324,8 +324,8 @@ class CmdUpdate(object):
                    is_template=False):
 
         run = run.strip()
-        query_ful = 'project.id:%s AND id:%s' % (TestRun.default_project,
-                                                 run)
+        query_ful = 'project.id:%s AND id:\"%s\"' % (TestRun.default_project,
+                                                     run)
 
         fields = ['query',
                   'created',


### PR DESCRIPTION
Added quotes to allow TestRun.search() to correctly process the string for test run id when it contains spaces.
Fixes: https://github.com/RedHatQE/pylero/issues/43