### PR TITLE
base_polarion: Add disable_manual_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ your CA to the cert_path config option.  These are the configurable values:
     password={your password}
     default_project={your default project}
     #cert_path=/dir/with/certs
+    #disable_manual_auth=False
 ```
 
 If the password value is blank, it will prompt you for a password when you try
@@ -93,6 +94,7 @@ These can also be overridden with the following environment variables:
     POLARION_TIMEOUT
     POLARION_PROJECT
     POLARION_CERT_PATH
+    POLARION_DISABLE_MANUAL_AUTH
 ```
 
 ## Requirements

--- a/src/pylero/base_polarion.py
+++ b/src/pylero/base_polarion.py
@@ -92,6 +92,14 @@ class Configuration(object):
                                      "valid values for: url, user, "
                                      "password and default_project")
 
+        try:
+            self.disable_manual_auth = \
+                os.environ.get("POLARION_DISABLE_MANUAL_AUTH") or \
+                config.getboolean(self.CONFIG_SECTION,
+                                  "disable_manual_auth")
+        except Exception:
+            self.disable_manual_auth = False
+
 
 class Connection(object):
     """Creates a Polarion session as a class method, so that it is used for all
@@ -137,6 +145,9 @@ class Connection(object):
                     if "com.polarion.platform.security." \
                             "AuthenticationFailedException" \
                             in e.fault.faultstring:
+                        if cfg.disable_manual_auth:
+                            raise PyleroLibException("Manual authentication "
+                                                     "is disabled")
                         cfg.pwd = getpass("Invalid Password.\nEnter Password:")
                         cls.password_retries -= 1
                     else:


### PR DESCRIPTION
Expose a config option 'disable_manual_auth' that will allow users to
disable manual prompot for re-authentication when providing incorrect
passowrd.

Resolves #61 