### PR TITLE
Don't change TestRun State automatically

### DIFF
--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -831,12 +831,13 @@ class TestRun(BasePolarion):
         self.add_test_record_by_object(testrec)
 
     @tx_wrapper
-    def add_test_record_by_object(self, test_record):
+    def add_test_record_by_object(self, test_record, manual_state_change=False):
         """method add_test_record_by_object, adds a test record for the given
         test case based on the TestRecord object passed in
 
         Args:
             test_record (TestRecord or Polarion TestRecord):
+            manual_state_change (boolean): change the test run result automatically or manual. 
 
         Returns:
             None
@@ -857,7 +858,11 @@ class TestRun(BasePolarion):
                                        TestCase(work_item_id=test_case_id))
         self.session.test_management_client.service.addTestRecordToTestRun(
             self.uri, suds_object)
-        self._status_change()
+
+        if manual_state_change:
+            self.update()
+        else:
+            self._status_change()
 
     def create_summary_defect(self, defect_template_id=None):
         """method create_summary_defect, adds a new summary _WorkItem for the
@@ -1172,13 +1177,14 @@ class TestRun(BasePolarion):
         self.update_test_record_by_object(test_case_id, testrec)
 
     @tx_wrapper
-    def update_test_record_by_object(self, test_case_id, test_record):
+    def update_test_record_by_object(self, test_case_id, test_record, manual_state_change=False):
         """method update_test_record_by_object, adds a test record for the
         given test case based on the TestRecord object passed in
 
         Args:
             test_case_id (str): the test case id that the record is related to.
             test_record (TestRecord or Polarion TestRecord)
+            manual_state_change (boolean): change the test run result automatically or manual. 
 
         Returns:
             None
@@ -1207,7 +1213,10 @@ class TestRun(BasePolarion):
                 suds_object = test_record
             self.session.test_management_client.service. \
                 updateTestRecordAtIndex(self.uri, index, suds_object)
-            self._status_change()
+            if manual_state_change:
+                self.update()
+            else:
+                self._status_change()
 
     def update_wiki_content(self, content):
         """method update_wiki_content updates the wiki for the current TestRun

--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -641,28 +641,6 @@ class TestRun(BasePolarion):
         raise PyleroLibException("The Test Case is either not part of "
                                  "this TestRun or has not been executed")
 
-    def _status_change(self):
-        # load a new object to test if the status should be changed.
-        # can't use existing object because it doesn't include the new test rec
-        # if the status needs changing, change it in the new object, so it
-        # doesn't update any user made changes in the existing object.
-        check_tr = TestRun(uri=self.uri)
-        results = [rec.result for rec in check_tr.records if rec.result]
-        if not results:
-            status = "notrun"
-            check_tr.finished_on = None
-        elif len(results) == len(check_tr.records):
-            status = "finished"
-            # Do not touch finished_on because it can not be reverted
-            # DPP-171495 Web services: You cannot reset finishedOn in TestRun
-            # check_tr.finished_on = datetime.datetime.now()
-        else:
-            status = "inprogress"
-            check_tr.finished_on = None
-        if status != check_tr.status:
-            check_tr.status = status
-            check_tr.update()
-
     def _verify_record_count(self, record_index):
         # verifies the number of records is not less then the index given.
         self._verify_obj()
@@ -857,7 +835,7 @@ class TestRun(BasePolarion):
                                        TestCase(work_item_id=test_case_id))
         self.session.test_management_client.service.addTestRecordToTestRun(
             self.uri, suds_object)
-        self._status_change()
+        self.update()
 
     def create_summary_defect(self, defect_template_id=None):
         """method create_summary_defect, adds a new summary _WorkItem for the
@@ -1207,7 +1185,7 @@ class TestRun(BasePolarion):
                 suds_object = test_record
             self.session.test_management_client.service. \
                 updateTestRecordAtIndex(self.uri, index, suds_object)
-            self._status_change()
+            self.update()
 
     def update_wiki_content(self, content):
         """method update_wiki_content updates the wiki for the current TestRun

--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -831,15 +831,19 @@ class TestRun(BasePolarion):
         self.add_test_record_by_object(testrec)
 
     @tx_wrapper
-    def add_test_record_by_object(self, test_record, manual_state_change=False):
+    def add_test_record_by_object(self,
+                                  test_record,
+                                  manual_state_change=False):
         """method add_test_record_by_object, adds a test record for the given
-        test case based on the TestRecord object passed in. In addition, the test run
-        is checked for completeness and the test run state will change accordingly. 
+        test case based on the TestRecord object passed in.
+        In addition, the test run is checked for completeness and the test
+        run state will change accordingly.
         Test Run states are ["notrun", "finished", "inprogress"].
 
         Args:
             test_record (TestRecord or Polarion TestRecord):
-            manual_state_change (boolean): Change the test run result automatically or manual. 
+            manual_state_change (boolean): Change test run state
+                                           automatically or manual.
 
         Returns:
             None
@@ -1179,16 +1183,21 @@ class TestRun(BasePolarion):
         self.update_test_record_by_object(test_case_id, testrec)
 
     @tx_wrapper
-    def update_test_record_by_object(self, test_case_id, test_record, manual_state_change=False):
+    def update_test_record_by_object(self,
+                                     test_case_id,
+                                     test_record,
+                                     manual_state_change=False):
         """method update_test_record_by_object, adds a test record for the
-        given test case based on the TestRecord object passed in. In addition, the test run
-        is checked for completeness and the test run state will change accordingly. 
+        given test case based on the TestRecord object passed in.
+        In addition, the test run is checked for completeness and the
+        test run state will change accordingly.
         Test Run states are ["notrun", "finished", "inprogress"].
 
         Args:
             test_case_id (str): the test case id that the record is related to.
             test_record (TestRecord or Polarion TestRecord)
-            manual_state_change (boolean): change the test run result automatically or manual. 
+            manual_state_change (boolean): Change the test
+                                           run result automatically or manual.
 
         Returns:
             None

--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -833,11 +833,13 @@ class TestRun(BasePolarion):
     @tx_wrapper
     def add_test_record_by_object(self, test_record, manual_state_change=False):
         """method add_test_record_by_object, adds a test record for the given
-        test case based on the TestRecord object passed in
+        test case based on the TestRecord object passed in. In addition, the test run
+        is checked for completeness and the test run state will change accordingly. 
+        Test Run states are ["notrun", "finished", "inprogress"].
 
         Args:
             test_record (TestRecord or Polarion TestRecord):
-            manual_state_change (boolean): change the test run result automatically or manual. 
+            manual_state_change (boolean): Change the test run result automatically or manual. 
 
         Returns:
             None
@@ -1179,7 +1181,9 @@ class TestRun(BasePolarion):
     @tx_wrapper
     def update_test_record_by_object(self, test_case_id, test_record, manual_state_change=False):
         """method update_test_record_by_object, adds a test record for the
-        given test case based on the TestRecord object passed in
+        given test case based on the TestRecord object passed in. In addition, the test run
+        is checked for completeness and the test run state will change accordingly. 
+        Test Run states are ["notrun", "finished", "inprogress"].
 
         Args:
             test_case_id (str): the test case id that the record is related to.


### PR DESCRIPTION
The TestRun should not set the state of the test run based on the provided test records because: 

- User can have custom test run states
- User wants to set the state manually
