### PR TITLE
Remove deprecated bdist_rpm cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ From the root of the project, run:
 
 ### Build rpm
 
-If you want to make an rpm out of it:
+If you want to make an rpm, make sure you have python wheel package installed:
 
-`$ python setup.py bdist_rpm`
+`$ python setup.py bdist_wheel`
 
 Pylero must be configured (see next section) before it can be used.
 

--- a/docs/_sources/index.rst.txt
+++ b/docs/_sources/index.rst.txt
@@ -61,9 +61,9 @@ From the root of the project, run::
 Build rpm
 ---------
 
-If you want to make an rpm out of it::
+If you want to make an rpm, make sure you have python wheel package installed:
 
-    $ python setup.py bdist_rpm
+    $ python setup.py bdist_wheel
 
 Pylero must be configured (see next section) before it can be used.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_rpm]
-requires = python-suds


### PR DESCRIPTION
- bdist_rpm cmd is deprecated and replaced by bdist_wheel
- Remove the setup.cfg file with the bdist_rpm config
- Update doc with the bdist_wheel cmd

Signed-off-by: Wayne Sun <gsun@redhat.com>