### PR TITLE
Update the rpmbuild spec

### DIFF
--- a/pylero.spec
+++ b/pylero.spec
@@ -7,7 +7,7 @@ Summary: Python SDK for Polarion
 Name: %{name}
 Version: %{version}
 Release: %{release}
-Source0: %{name}-%{unmangled_version}.tar.gz
+Source0: https://github.com/RedHatQE/pylero/archive/refs/tags/%{unmangled_version}.tar.gz
 License: MIT
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
@@ -46,16 +46,13 @@ objects (such as TestCase), the library connects to the Polarion server,
 downloads the list of workitems and creates them.
 
 %prep
-%setup -n %{name}-%{unmangled_version} -n %{name}-%{unmangled_version}
+%setup -q -n %{name}-%{unmangled_version} -n %{name}-%{unmangled_version}
 
 %build
 python3 setup.py build
 
 %install
 python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files -f INSTALLED_FILES
 %defattr(-,root,root)


### PR DESCRIPTION
Fix error and warning with rpmlint:

- Remove the clean part
- Add '-q' option at setup
- Update source to github release url.

To build rpm, first run:

$ spectool -gR pylero.spec

to download the source file into local build dir.

Then run rpmbuild command with:

$ rpmbuild -ba pylero.spec

Signed-off-by: Wayne Sun <gsun@redhat.com>