### PR TITLE
Fix customFields not set error

### DIFF
--- a/src/pylero/base_polarion.py
+++ b/src/pylero/base_polarion.py
@@ -14,7 +14,7 @@ from getpass import getpass
 import suds
 from pylero._compatible import basestring
 from pylero._compatible import classmethod
-from pylero._compatible import SafeConfigParser
+from pylero._compatible import ConfigParser
 from pylero.exceptions import PyleroLibException
 from pylero.server import Server
 
@@ -42,7 +42,7 @@ class Configuration(object):
     def __init__(self):
         defaults = {"cachingpolicy": "0",
                     "timeout": "120"}
-        config = SafeConfigParser(defaults)
+        config = ConfigParser(defaults)
         # Check for existence of config file and config_section
         if not config.read([self.GLOBAL_CONFIG, self.LOCAL_CONFIG,
                             self.CURDIR_CONFIG]) or \
@@ -598,7 +598,8 @@ class BasePolarion(object):
                 if test_steps:
                     return test_steps
         else:
-            if "customFields" not in self._suds_object:
+            if (("customFields" not in self._suds_object) or
+                    (not self._suds_object.customFields)):
                 self._suds_object.customFields = self.custom_array_obj()
             cf = self._suds_object.customFields[0]
             custom_fld = None
@@ -707,7 +708,8 @@ class BasePolarion(object):
                 raise PyleroLibException(
                     "The value must be of type {0}."
                     .format(csm["cls"].__name__))
-            if "customFields" not in self._suds_object:
+            if (("customFields" not in self._suds_object) or
+                    (not self._suds_object.customFields)):
                 self._suds_object.customFields = self.custom_array_obj()
             cf = self._suds_object.customFields[0]
             if cf:

--- a/src/pylero/session.py
+++ b/src/pylero/session.py
@@ -9,6 +9,7 @@ import re
 import ssl
 import time
 
+import suds.client
 import suds.sax.element
 from pylero._compatible import builtins  # noqa
 from pylero._compatible import object

--- a/src/unit_tests/attribute_test.py
+++ b/src/unit_tests/attribute_test.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 import datetime
 
-import unittest2
+import unittest
 from pylero.document import Document
 from pylero.exceptions import PyleroLibException
 from pylero.test_record import TestRecord
@@ -30,7 +30,7 @@ DOC_NAME = "Document_Test-%s" % TIME_STAMP
 DEFAULT_PROJ = Document.default_project
 
 
-class AttributeTest(unittest2.TestCase):
+class AttributeTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -188,4 +188,4 @@ class AttributeTest(unittest2.TestCase):
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
-    unittest2.main()
+    unittest.main()

--- a/src/unit_tests/document_test.py
+++ b/src/unit_tests/document_test.py
@@ -5,7 +5,7 @@ Created on Apr 13, 2015
 '''
 import datetime
 
-import unittest2
+import unittest
 from pylero.document import Document
 from pylero.test_run import TestRun
 from pylero.work_item import TestCase
@@ -20,7 +20,7 @@ TEMPLATE_TITLE = "doc_tmp_test-%s" % TIME_STAMP
 TEST_RUN_TITLE = "doc_test-%s" % TIME_STAMP
 
 
-class DocumentTest(unittest2.TestCase):
+class DocumentTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -93,4 +93,4 @@ class DocumentTest(unittest2.TestCase):
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
-    unittest2.main()
+    unittest.main()

--- a/src/unit_tests/plan_test.py
+++ b/src/unit_tests/plan_test.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 
-import unittest2
+import unittest
 from pylero.exceptions import PyleroLibException
 from pylero.plan import Plan
 from pylero.work_item import Requirement
@@ -16,7 +16,7 @@ ATTACH_PATH = CUR_PATH + "/refs/red_box.png"
 ATTACH_TITLE = "File"
 
 
-class PlanTest(unittest2.TestCase):
+class PlanTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -104,4 +104,4 @@ class PlanTest(unittest2.TestCase):
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
-    unittest2.main()
+    unittest.main()

--- a/src/unit_tests/test_run_test.py
+++ b/src/unit_tests/test_run_test.py
@@ -6,7 +6,7 @@ Created on Apr 19, 2015
 import datetime
 import os
 
-import unittest2
+import unittest
 from pylero.exceptions import PyleroLibException
 from pylero.plan import Plan
 from pylero.test_record import TestRecord
@@ -33,7 +33,7 @@ TITLE2 = "title2_regr-%s" % TIME_STAMP
 TEST_RUN_ID2 = "tr2_regr-%s" % TIME_STAMP
 
 
-class TestRunTest(unittest2.TestCase):
+class TestRunTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -387,4 +387,4 @@ class TestRunTest(unittest2.TestCase):
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
-    unittest2.main()
+    unittest.main()

--- a/src/unit_tests/work_item_test.py
+++ b/src/unit_tests/work_item_test.py
@@ -5,7 +5,7 @@ Created on Apr 15, 2015
 '''
 import os
 
-import unittest2
+import unittest
 from pylero.exceptions import PyleroLibException
 from pylero.test_step import TestStep
 from pylero.work_item import Requirement
@@ -17,7 +17,7 @@ CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 ATTACH_PATH = CUR_PATH + "/refs/red_box.png"
 
 
-class WorkItemTest(unittest2.TestCase):
+class WorkItemTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -267,4 +267,4 @@ class WorkItemTest(unittest2.TestCase):
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
-    unittest2.main()
+    unittest.main()


### PR DESCRIPTION
When customFields could be found and value is None, also need
update the customFields.

Remove deprecated SafeConfigParser.

Fix suds import issue in the session module.

Fix unittest import in tests.

Signed-off-by: Wayne Sun <gsun@redhat.com>