### PR TITLE
Remove deprecated assertEquals

### DIFF
--- a/src/unit_tests/document_test.py
+++ b/src/unit_tests/document_test.py
@@ -87,8 +87,8 @@ class DocumentTest(unittest2.TestCase):
                             template=TEMPLATE_ID,
                             title=TEST_RUN_TITLE)
         TEST_RUN_ID = tr.test_run_id
-        self.assertEquals(len(tr.records), 1)
-        self.assertEquals(tr.records[0].test_case_id, WI_ID)
+        self.assertEqual(len(tr.records), 1)
+        self.assertEqual(tr.records[0].test_case_id, WI_ID)
         self.doc_create.session.tx_commit()
 
 if __name__ == "__main__":

--- a/src/unit_tests/plan_test.py
+++ b/src/unit_tests/plan_test.py
@@ -57,37 +57,37 @@ class PlanTest(unittest2.TestCase):
 
     def test_003_search_template(self):
         lst_res = Plan.search("id:%s" % TEMPLATE_ID, search_templates=True)
-        self.assertEquals(len(lst_res), 1)
-        self.assertEquals(lst_res[0].plan_id, TEMPLATE_ID)
+        self.assertEqual(len(lst_res), 1)
+        self.assertEqual(lst_res[0].plan_id, TEMPLATE_ID)
 
     def test_004_search_plan(self):
         lst_res = Plan.search("id:%s" % PLAN_ID)
-        self.assertEquals(len(lst_res), 1)
-        self.assertEquals(lst_res[0].plan_id, PLAN_ID)
+        self.assertEqual(len(lst_res), 1)
+        self.assertEqual(lst_res[0].plan_id, PLAN_ID)
 
     def test_005_get_plan(self):
         plan = Plan(project_id=DEFAULT_PROJ, plan_id=PLAN_ID)
-        self.assertEquals(plan.plan_id, PLAN_ID)
+        self.assertEqual(plan.plan_id, PLAN_ID)
         plan2 = Plan(uri=plan.uri)
-        self.assertEquals(plan2.plan_id, PLAN_ID)
+        self.assertEqual(plan2.plan_id, PLAN_ID)
 
     def test_006_add_items(self):
         plan = Plan(project_id=DEFAULT_PROJ, plan_id=PLAN_ID)
         plan.add_plan_items([self.NEW_REQ, self.NEW_REQ2])
         plan.reload()
-        self.assertEquals(len(plan.records), 2)
+        self.assertEqual(len(plan.records), 2)
 
     def test_007_stats(self):
         plan = Plan(project_id=DEFAULT_PROJ, plan_id=PLAN_ID)
         stats = plan.get_statistics()
-        self.assertEquals(stats.number_of_planned, 2)
+        self.assertEqual(stats.number_of_planned, 2)
 
     def test_008_remove_wi(self):
         plan = Plan(project_id=DEFAULT_PROJ, plan_id=PLAN_ID)
         plan.remove_plan_items([self.NEW_REQ])
         plan.reload()
-        self.assertEquals(len(plan.records), 1)
-        self.assertEquals(plan.records[0].item, self.NEW_REQ2)
+        self.assertEqual(len(plan.records), 1)
+        self.assertEqual(plan.records[0].item, self.NEW_REQ2)
 
     def test_009_update(self):
         plan = Plan(project_id=DEFAULT_PROJ, plan_id=PLAN_ID)
@@ -95,7 +95,7 @@ class PlanTest(unittest2.TestCase):
         plan.update()
         plan.color = ""
         plan.reload()
-        self.assertEquals(plan.color, "red")
+        self.assertEqual(plan.color, "red")
 
     def test_010_delete(self):
         Plan.delete_plans(DEFAULT_PROJ, PLAN_ID)

--- a/src/unit_tests/test_run_test.py
+++ b/src/unit_tests/test_run_test.py
@@ -283,16 +283,16 @@ class TestRunTest(unittest2.TestCase):
         tr = TestRun.create(DEFAULT_PROJ, "querytest-%s" % TIME_STAMP,
                             "Example",
                             "querytest-%s" % TIME_STAMP, query=TIME_STAMP)
-        self.assertEquals(tr.select_test_cases_by, "dynamicQueryResult")
+        self.assertEqual(tr.select_test_cases_by, "dynamicQueryResult")
         num_recs = len(tr.records)
         test_case_id = tr.records[0].test_case_id
         tr.update_test_record_by_fields(test_case_id, "blocked", "comment",
                                         tr.logged_in_user_id,
                                         datetime.datetime.now(), 0)
         tr.reload()
-        self.assertEquals(num_recs, len(tr.records))
-        self.assertEquals(test_case_id, tr.records[0].test_case_id)
-        self.assertEquals(tr.records[0].result, "blocked")
+        self.assertEqual(num_recs, len(tr.records))
+        self.assertEqual(test_case_id, tr.records[0].test_case_id)
+        self.assertEqual(tr.records[0].result, "blocked")
 
     def test_010_search_with_custom_fields(self):
         """This test does the following:
@@ -323,7 +323,7 @@ class TestRunTest(unittest2.TestCase):
         with self.assertRaises(PyleroLibException):
             tr.plannedin = "not_valid"
         tr.plannedin = self.NEW_PLAN
-        self.assertEquals(tr.plannedin, self.NEW_PLAN)
+        self.assertEqual(tr.plannedin, self.NEW_PLAN)
         tr.update()
 
     def test_012_search_with_URI_fields(self):

--- a/src/unit_tests/work_item_test.py
+++ b/src/unit_tests/work_item_test.py
@@ -55,7 +55,7 @@ class WorkItemTest(unittest2.TestCase):
             "project.id:%s AND title:regression" % (DEFAULT_PROJ),
             fields=["work_item_id", "caseautomation"])
         tc = results3[0]
-        self.assertEquals(tc.caseautomation, "notautomated")
+        self.assertEqual(tc.caseautomation, "notautomated")
 
     def test_002_get_item(self):
         tc = TestCase(project_id=DEFAULT_PROJ,


### PR DESCRIPTION
assertEquals is deprecated in python 3, replace it with assertEqual

Signed-off-by: Wayne Sun <gsun@redhat.com>