### PR TITLE
Switch from suds-py3 to suds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-suds-py3
+suds
 click
 readline; python_version <= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import sys
+import os
 from distutils.command.install import INSTALL_SCHEMES
 
 from setuptools import setup
@@ -8,16 +8,30 @@ with open("README.md", "r") as handle:
 
 PACKAGE_NAME = "pylero"
 CLI_NAME = "pylero-cmd"
+RELEASE_FILE = "/etc/system-release-cpe"
+SUDS_NAME_CHANGE = False
 
 # change the data dir to be the etc dir under the package dir
 for scheme in list(INSTALL_SCHEMES.values()):
     scheme['data'] = '%s/%s/etc' % (scheme['purelib'], PACKAGE_NAME)
 
 install_requires_ = [
-    'suds-py3',
     'click',
-    'pre-commit',
 ]
+
+# Update install_requires_ for feodra 36 and greater
+if os.path.exists(RELEASE_FILE):
+    with open(RELEASE_FILE) as version_file:
+        version_file_content = version_file.read().split(":")
+        if (version_file_content[3] == "fedora") and (
+                int(version_file_content[4]) > 35):
+            SUDS_NAME_CHANGE = True
+
+if SUDS_NAME_CHANGE:
+    install_requires_.append('suds')
+else:
+    install_requires_.append('suds-community')
+
 
 if __name__ == "__main__":
     setup(
@@ -50,7 +64,7 @@ if __name__ == "__main__":
             'Intended Audience :: Developers',      # Define that your audience are developers
             'Topic :: Software Development :: Build Tools',
             'License :: OSI Approved :: MIT License',   # Again, pick a license
-            'Programming Language :: Python :: 3',      #Specify which pyhton versions that you want to support
+            'Programming Language :: Python :: 3',      # Specify which pyhton versions that you want to support
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
The suds-community project suds is the project inherit from the
original suds project, and suds-py3 is another community fork
without much active contribution.

Switch back to the suds-community suds project which also have
fedora release.

Update suds dependency base on version in the setup. On Fedora 36
the python3.10dist(suds) rpm package could be found but on earlier
version it should look for python3dist(suds-community).

Signed-off-by: Wayne Sun <gsun@redhat.com>