### PR TITLE
Downgrade spec format version to 201x era

### DIFF
--- a/pylero.spec
+++ b/pylero.spec
@@ -16,10 +16,14 @@ Vendor: pylero Developers <gsun@redhat.com>
 URL: https://github.com/RedHatQE/pylero
 SOURCE: %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
+Requires: python3-%{name} == %{version}-%{release}
+Requires: python3-suds python3-click
+
 BuildArch: noarch
 BuildRequires: python3-devel
 BuildRequires: python3-suds
 BuildRequires: python3-click
+BuildRequires: python3-setuptools
 
 %global _description %{expand:
 # Pylero
@@ -60,21 +64,19 @@ Summary:        %{summary}
 %prep
 %autosetup -p1 -n %{name}-%{version}
 
-%generate_buildrequires
-%pyproject_buildrequires
-
 %build
-%pyproject_wheel
+%py3_build
 
 %install
-%pyproject_install
+%py3_install
 
-%pyproject_save_files %{name}
-
-%files -n python3-%{name} -f %{pyproject_files}
+%files -n python3-%{name}
+%{python3_sitelib}/%{name}-*.egg-info/
+%{python3_sitelib}/%{name}/
+%license LICENSE
 %doc README.md
 %{_bindir}/%{name}-cmd
-
+%exclude %{_bindir}/%{name}
 
 %changelog
 * Mon May 23 2022 Wayne Sun <gsun@redhat.com> - 0.0.2-1

--- a/pylero.spec
+++ b/pylero.spec
@@ -2,21 +2,26 @@
 %define version 0.0.2
 %define unmangled_version 0.0.2
 %define release 1
+%define _unpackaged_files_terminate_build 0
 
 Summary: Python SDK for Polarion
 Name: %{name}
 Version: %{version}
 Release: %{release}
-Source0: https://github.com/RedHatQE/pylero/archive/refs/tags/%{unmangled_version}.tar.gz
 License: MIT
 Group: Development/Libraries
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}
-BuildArch: noarch
 Vendor: pylero Developers <gsun@redhat.com>
-Url: https://github.com/RedHatQE/pylero
 
-%description
+URL: https://github.com/RedHatQE/pylero
+SOURCE: %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildArch: noarch
+BuildRequires: python3-devel
+BuildRequires: python3-suds
+BuildRequires: python3-click
+
+%global _description %{expand:
 # Pylero
 
 Welcome to Pylero, the Python wrapper for the Polarion WSDL API. The Pylero
@@ -43,19 +48,33 @@ time.
 
 Polarion Work Items are configured per installation, to give native workitem
 objects (such as TestCase), the library connects to the Polarion server,
-downloads the list of workitems and creates them.
+downloads the list of workitems and creates them.}
+
+%description %_description
+
+%package -n python3-%{name}
+Summary:        %{summary}
+
+%description -n python3-%{name} %_description
 
 %prep
-%setup -q -n %{name}-%{unmangled_version} -n %{name}-%{unmangled_version}
+%autosetup -p1 -n %{name}-%{version}
+
+%generate_buildrequires
+%pyproject_buildrequires
 
 %build
-python3 setup.py build
+%pyproject_wheel
 
 %install
-python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+%pyproject_install
 
-%files -f INSTALLED_FILES
-%defattr(-,root,root)
+%pyproject_save_files %{name}
+
+%files -n python3-%{name} -f %{pyproject_files}
+%doc README.md
+%{_bindir}/%{name}-cmd
+
 
 %changelog
 * Mon May 23 2022 Wayne Sun <gsun@redhat.com> - 0.0.2-1


### PR DESCRIPTION
The current spec format is not working on EPEL8, detail could be found in [1].
So switch back to the 201x era format which could works on EPEL8, EPEL9 and
supported Fedora releases.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/