### PR TITLE
Using modern pypi package build system interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,16 @@ From the root of the project, run:
 
 `$ pip install .`
 
-### Build rpm
+### Build pip package
 
-If you want to make an rpm, make sure you have python wheel package installed:
+After cloned the repo and in the dir:
 
-`$ python setup.py bdist_wheel`
+`$ python -m build`
+
+both wheel and bdist format will be built and the package could be found under
+dist directory.
+
+Then both files could be used to install the package with pip install locally.
 
 Pylero must be configured (see next section) before it can be used.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm", "wheel"]


### PR DESCRIPTION
The modern python packages use pyproject.toml as build interface. The file contains build system requirements and information, which are used by pip to build the package.

To build a pip package:

$ python -m build

Signed-off-by: Wayne Sun <gsun@redhat.com>