### PR TITLE
Switch back to modern rpm spec

### DIFF
--- a/pylero.spec
+++ b/pylero.spec
@@ -51,21 +51,25 @@ Summary:        %{summary}
 
 %prep
 %autosetup -p1 -n %{name}-%{version}
+# setuptools-scm is needed to build the source distribution, but not
+# for packaging, which *starts* from the source distribution
+sed -i -e 's., "setuptools_scm"..g' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
 
 %build
-%py3_build
+%pyproject_wheel
 
 %install
-%py3_install
+%pyproject_install
 rm -f %{buildroot}%{_bindir}/pylero
 
 %files -n python3-%{name}
-%{python3_sitelib}/%{name}-*.egg-info/
-%{python3_sitelib}/%{name}/
-%license LICENSE
 %doc README.md
+%license LICENSE
+%{python3_sitelib}/%{name}*
 %{_bindir}/%{name}-cmd
-%exclude %{_bindir}/%{name}
 
 %changelog
 * Tue Aug 02 2022 Wayne Sun <gsun@redhat.com> 0.0.3-1

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,13 @@ install_requires_ = [
 if os.path.exists(RELEASE_FILE):
     with open(RELEASE_FILE) as version_file:
         version_file_content = version_file.read().split(":")
-        if (version_file_content[3] == "fedora") and (
-            int(version_file_content[4]) > 35
+        if (
+            (version_file_content[3] == "fedora")
+            and (int(version_file_content[4]) > 35)
+        ) or (
+            (version_file_content[2] == "redhat")
+            and (version_file_content[3] == "enterprise_linux")
+            and (int(version_file_content[4].split(".")[0]) > 8)
         ):
             SUDS_NAME_CHANGE = True
 


### PR DESCRIPTION
The modern spec could be used to build rpm on supported Fedora
releases, it could not be used to build on epel8 and earlier.

For build rpm on epel8 and earlier, must use the old 201x era 
spec which don't need exist in the upstream repo.

Remove the setuptools_scm dependency in pyproject.toml during
package build from the spec as it's for source build not for 
packaging.

Signed-off-by: Wayne Sun <gsun@redhat.com>