### PR TITLE
Set project id for accepted objects

### DIFF
--- a/src/pylero/base_polarion.py
+++ b/src/pylero/base_polarion.py
@@ -562,9 +562,15 @@ class BasePolarion(object):
         csm = self._cls_suds_map[field_name]
         if getattr(self._suds_object, csm["field_name"], None):
             obj_lst = []
+            project_id = getattr(self._suds_object, "project", None)
+            if project_id:
+                project_id = project_id["id"]
             # ArrayOf Polarion objects have a double list.
             for inst in getattr(self._suds_object, csm["field_name"])[0]:
-                obj_lst.append(csm["cls"](suds_object=inst))
+                csm_obj = csm["cls"](suds_object=inst)
+                if getattr(csm_obj, "project_id", None) and project_id:
+                    setattr(csm_obj, "project_id", project_id)
+                obj_lst.append(csm_obj)
             return obj_lst
         else:
             return []


### PR DESCRIPTION
Issue:
- When an Object is instantiated via Base Polarion we aren't sending
  project_id for that object
- As a result every object is using default_project during obj creation

Resolution:
- If the suds object of a python obj has project id, instantiate python
  object with project id
- This commit only perform above op for array type objects
- I'm not making changes to other types of object intentionally as to
  reduce the blast area if there's any and also being as specific to the
  linked issue reported

Edge Case:
- Assumes the child obj (let's say linked work item) belongs to same
  parent object (let's say testcase)
- IOW no cross linking from child object to parent object in another
  project

Unit tests:
```
Ran 62 tests in 435.839s

FAILED (errors=5)
```

Feature testing (replaced some identifiable names):
``` python
>>> from pylero.work_item import TestCase
>>> tc = TestCase(project_id="RHGX", work_item_id="RHGX-12525")
>>> tc.linked_work_items[0].project_id
RHGX
>>> tc.default_project
'pylxxion'
>>>
```

fixes: https://github.com/RedHatQE/pylero/issues/102

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>