### PR TITLE
Remove deprecated SafeConfigParser

### DIFF
--- a/src/pylero/_compatible.py
+++ b/src/pylero/_compatible.py
@@ -50,8 +50,3 @@ try:
     from ConfigParser import ConfigParser
 except ImportError:
     from configparser import ConfigParser
-
-try:
-    from ConfigParser import SafeConfigParser
-except ImportError:
-    from configparser import SafeConfigParser


### PR DESCRIPTION
The deprecated SafeConfigParser is removed from python 3.12 and is not needed as already using ConfigParser, remove it from the compability module.

Signed-off-by: Wayne Sun <gsun@redhat.com>