### PR TITLE
Pin github action ubuntu image to ubuntu-20.04

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,10 +8,12 @@ on:
 jobs:
   codechecks:
     name: Code Quality
-    runs-on: ubuntu-latest
+    # The last image version support python3.6, latest have removed it
+    # Still need python3.6 for EPEL8
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.8, 3.9, "3.10", "3.11"]
     steps:
       - name: Checkout Pylero
         uses: actions/checkout@v3


### PR DESCRIPTION
ubuntu-20.04 support python 3.6 which is removed from latest image.

Also add 3.11 in the matrix, 3.12 have not arrived in the ubuntu image yet.

Reference:
https://github.com/actions/setup-python/issues/544

Signed-off-by: Wayne Sun <gsun@redhat.com>