### PR TITLE
add replace to handle "/" in work item type class

### DIFF
--- a/src/pylero/work_item.py
+++ b/src/pylero/work_item.py
@@ -1591,7 +1591,7 @@ bp = BasePolarion()
 vals = bp.get_valid_field_values("workitem-type")
 workitems = {}
 for item in bp._cache["enums"]["workitem-type"][None]:
-    workitems[item.id] = item.name.replace(" ", "")
+    workitems[item.id] = item.name.replace(" ", "").replace("/", "")
 
 for wi in workitems:
     newclass = type(


### PR DESCRIPTION
I wanted to use the SoftwareInput/Output class but that was not possible.

Workaround replace the "/" in class names.

example case:
<class 'pylero.work_item.SoftwareInput/Output'>

Is there a better way to handle this issue? Or am i missing something?