### PR TITLE
Fix custom field description update

### DIFF
--- a/src/pylero/cli/cmd.py
+++ b/src/pylero/cli/cmd.py
@@ -346,7 +346,7 @@ class CmdUpdate(object):
                 tr.status = status
                 print("%4sSet Status to %s" % ("", status))
             if description is not None:
-                tr.description = description
+                tr.description.content = description
                 print("%4sSet Description to %s" % ("", description))
             tr.update()
 


### PR DESCRIPTION
The description field is a Text field and need update the Text content.

This fix does not include check description type but directly update content, which is good enough.