### PR TITLE
Fixing issue #160

### DIFF
--- a/src/pylero/work_item.py
+++ b/src/pylero/work_item.py
@@ -1459,6 +1459,8 @@ class _SpecificWorkItem(_WorkItem):
             # for all object types, I need special processing.
             parse_type = cft.type.split(":")
             if parse_type[0].startswith("ns"):
+                if parse_type[1] not in globals():
+                    continue
                 cls._cls_suds_map[local_name]["cls"] = globals()[parse_type[1]]
             cls._cls_suds_map[local_name]["enum_id"] = getattr(cft, "enum_id", None)
             cls._cls_suds_map[local_name]["is_custom"] = True


### PR DESCRIPTION
code :

if parse_type[0].startswith("ns"):
cls._cls_suds_map[local_name]["cls"] = globals()[parse_type[1]] cls._cls_suds_map[local_name]["enum_id"] = getattr(cft, "enum_id", None) cls._cls_suds_map[local_name]["is_custom"] = True
cls._cls_suds_map[local_name]["control"] = cls._wi_type

Error :

File "/home/emesika/.local/lib/python3.9/site-packages/pylero/work_item.py", line 1464, in get_custom_fields print(f"Global = {globals()[parse_type[1]]}")
KeyError: 'duration'

Happens on :

local name = sprint_estimate
parse_type = duration

should skip non existing parse_type[1] in globals() :

if parse_type[0].startswith("ns"):
if parse_type[1] not in globals():
continue
cls._cls_suds_map[local_name]["cls"] = globals()[parse_type[1]] cls._cls_suds_map[local_name]["enum_id"] = getattr(cft, "enum_id", None) cls._cls_suds_map[local_name]["is_custom"] = True
cls._cls_suds_map[local_name]["control"] = cls._wi_type