### PR TITLE
conditionally import TestCase in TestRun module

### DIFF
--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -32,6 +32,11 @@ from pylero.text import Text
 from pylero.user import User
 from pylero.work_item import _WorkItem
 
+try:
+    from pylero.work_item import TestCase
+except ImportError:
+    pass
+
 # Build is used in custom fields.
 # Plan is used in custom fields.
 
@@ -930,7 +935,7 @@ class TestRun(BasePolarion):
             suds_object = test_record
         if test_record.result == "failed" and not test_record.defect_case_id:
             test_record.defect_case_id = create_incident_report(
-                self, test_record, _WorkItem(work_item_id=test_case_id)
+                self, test_record, TestCase(work_item_id=test_case_id)
             )
         self.session.test_management_client.service.addTestRecordToTestRun(
             self.uri, suds_object
@@ -1306,7 +1311,7 @@ class TestRun(BasePolarion):
         else:
             if test_record.result == "failed" and not test_record.defect_case_id:
                 test_record.defect_case_id = create_incident_report(
-                    self, test_record, _WorkItem(work_item_id=test_case_id)
+                    self, test_record, TestCase(work_item_id=test_case_id)
                 )
             index = test_case_ids.index(test_case_id)
             if isinstance(test_record, TestRecord):


### PR DESCRIPTION
this pr is almost a revert for #132, after much deliberation and trial & error I believe solving the immediate issue of unblocking tagging release is important over providing a generic interface for the testrun to work w/ server instance specific workitems while creating incident reports.

other tried flows include creating a meta class (or instantiate workitem class) when testcase is referenced and adding it to globals and reuse wherever required, however this also builds on we knowing that there'll be a testcase item on the server instance.

initial report suggests failure in imports of testrun and if those users tried to update their similar testcase item it'll fail while generating report and conditionally importing testcase seems much better rather than trying to re-instate older working behavior with only using `_WorkItem` type

fixes: #134