### PR TITLE
Add Python 3.12 in the CI coverage

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout Pylero
         uses: actions/checkout@v3
@@ -31,4 +31,3 @@ jobs:
 
       - name: Pre Commit Checks
         uses: pre-commit/action@v3.0.0
-        if: ${{ matrix.python-version != '3.6' }}


### PR DESCRIPTION
Add Python 3.12, and also remove the EOL 3.6 out.