### PR TITLE
fix: erase title only for subcomments

### DIFF
--- a/src/pylero/work_item.py
+++ b/src/pylero/work_item.py
@@ -749,9 +749,9 @@ class _WorkItem(BasePolarion):
             suds_content = suds.null()
         if parent_uri is None:
             parent_uri = self.uri
-            title = None
         else:
             parent_uri = str(parent_uri)
+            title = None
             is_existing_comment = any([str(c.uri) == parent_uri for c in self.comments])
             if not is_existing_comment:
                 raise PyleroLibException(


### PR DESCRIPTION
This fixes a blunder I am to blame for (introduced here: https://github.com/RedHatQE/pylero/pull/172).
The expected behavior is: Set the title to `None` if the new comment is an answer to an existing comment.