### PR TITLE
fix(session): set CERT_PATH before WSDL client initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,16 @@
 # configuration for pre-commit git hooks
 exclude: '^docs'
 repos:
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.9.0
-  hooks:
-  - id: reorder-python-imports
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: debug-statements
   - id: detect-private-key
-- repo: https://github.com/psf/black
-  rev: 23.3.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.8.4
   hooks:
-  - id: black
+  - id: ruff
+    args: [--fix]
+  - id: ruff-format

--- a/CONTRIBUTION.rst
+++ b/CONTRIBUTION.rst
@@ -9,46 +9,13 @@ Setting up the environment
 ==========================
 
 -----------------
-Installing pip
+Installing uv
 -----------------
-This project uses `pip <https://pip.pypa.io/en/stable/>`_ as a package manager. To install, simply run the follow command:
+This project uses `uv <https://docs.astral.sh/uv/>`_ as a package manager. To install uv, simply run:
 
 .. code-block:: bash
 
-    $ python -m pip install
-
-------------------------
-Installing pre-commit
-------------------------
-`pre-commit <https://pre-commit.com/>`_ is a multi-language package manager for pre-commit hooks. It is used to check code before it makes it to commit. A list of hooks is specified in `.pre-commit-config.yaml` in the root directory of the project.
-To install `pre-commit`, simply run the following command:
-
-.. code-block:: bash
-
-    $ pip install pre-commit
-
-
------------------
-Before you commit
------------------
-
-In order to ensure you are able to pass the GitHub CI build, it is recommended that you run the following commands in the base of your pylero directory
-
-.. code-block:: python
-
-    $ pre-commit autoupdate && pre-commit run -a
-
-
-
-Pre-commit will ensure that the changes you made are not in violation of PEP8 standards and automatically apply black fixes.
-
-We recommend `black` to automatically fix any pre-commit failures.
-
-.. code-block:: python
-
-    $ pip install black
-    $ black <edited_file.py>
-
+    $ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 -----------------------------------
 Fork the project and clone the repo
@@ -64,27 +31,55 @@ Fork the project and clone the repo
 Installing dependencies
 -----------------------
 
-All the project dependencies are listed in `requirements.txt` file located in the root directory. To install all the dependencies of the project, simply run:
+Create a virtual environment and install all dependencies:
 
 .. code-block:: bash
 
-    $ pip install -r requirements.txt
-
-
+    $ uv venv
+    $ uv pip install -e .
+    $ uv pip install pre-commit ruff
 
 -----------------------------
 Setting up configuration file
 -----------------------------
 You will need to setup config values, for that you need to get some values from Polarion and provide it to the config file. For more detail, check out project's `README.md <https://github.com/RedHatQE/pylero/blob/main/README.md#configuration>`_
 
-----------------------------
-Install the project with pip
-----------------------------
-`Pylero` supports command line interface. Simply run `pylero` on you terminal, it will prompt to the command line interface. However, before you can do that you will have to install the project by running:
+------------------------
+Installing pre-commit
+------------------------
+`pre-commit <https://pre-commit.com/>`_ is a multi-language package manager for pre-commit hooks. It is used to check code before it makes it to commit. A list of hooks is specified in `.pre-commit-config.yaml` in the root directory of the project.
 
 .. code-block:: bash
 
-    $ pip install .
+    $ pre-commit install
+
+-----------------
+Before you commit
+-----------------
+
+In order to ensure you are able to pass the GitHub CI build, it is recommended that you run the following commands in the base of your pylero directory:
+
+.. code-block:: bash
+
+    $ pre-commit run -a
+
+Pre-commit will ensure that the changes you made are not in violation of PEP8 standards and automatically apply ruff fixes.
+
+You can also run `ruff` directly to fix any issues:
+
+.. code-block:: bash
+
+    $ ruff check --fix .
+    $ ruff format .
+
+----------------------------
+Install the project with uv
+----------------------------
+`Pylero` supports command line interface. Simply run `pylero` on your terminal, it will prompt to the command line interface. However, before you can do that you will have to install the project by running:
+
+.. code-block:: bash
+
+    $ uv pip install -e .
 
 in your project root directory. With that, you're ready to submit your first contribution.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 import os
-import shlex
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -38,9 +37,7 @@ extensions = [
 ]
 
 POLARION_URL = "https://almdemo.polarion.com"
-pol_client = "{}/polarion/sdk/doc/javadoc/com/polarion/alm/ws/client".format(
-    POLARION_URL
-)
+pol_client = "{}/polarion/sdk/doc/javadoc/com/polarion/alm/ws/client".format(POLARION_URL)
 
 extlinks = {
     "project": ("{}/projects/ProjectWebService.html#%s".format(pol_client), "%s"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,22 @@
 [build-system]
 requires = ["setuptools>=45", "setuptools_scm", "wheel"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pylero"]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.uv]
+dev-dependencies = [
+    "pre-commit",
+    "ruff",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 suds
 click
-readline; python_version <= '3.6'

--- a/scripts/pylero
+++ b/scripts/pylero
@@ -11,14 +11,14 @@ import pylero
 # import, pressing the arrow keys shows ctrl chars.
 if sys.version_info > (3, 6):
     try:
-        import gnureadline as readline
+        import gnureadline as readline  # noqa: F401
     except ImportError:
         # `readline` is deprecated and `gnureadline` requires `Python.h` and
         # `ncurses-devel` packages. TODO: Furnish steps to install `gnureadline`
         pass
 else:
     # `readline` on python > 3.6 resulting in Traceback at times
-    import readline
+    pass
 
 USAGE = """\
 Welcome to Pylero, the Python wrapper for the Polarion WSDL API. The Pylero

--- a/scripts/pylero-cmd
+++ b/scripts/pylero-cmd
@@ -46,8 +46,7 @@ if len(sys.argv) == 2 and sys.argv[1] in ("-h", "--help"):
     print(USAGE)
     sys.exit(0)
 
-from pylero.cli.cmd import CmdList
-from pylero.cli.cmd import CmdUpdate
+from pylero.cli.cmd import CmdList, CmdUpdate  # noqa: E402
 
 
 @click.group()
@@ -97,9 +96,7 @@ def cli():
     is_flag=True,
     help="flag indicating that the action will reference workitem",
 )
-@click.option(
-    "-w", "--wi_type", default="", help="type of workitem. e.g testcase, requirement"
-)
+@click.option("-w", "--wi_type", default="", help="type of workitem. e.g testcase, requirement")
 def list(
     document,
     query,
@@ -123,7 +120,7 @@ def list(
     # get documents
     if is_document and query:
         docs = list_obj.list_documents_by_query(query)
-        list_obj.print_documents(docs),
+        (list_obj.print_documents(docs),)
 
     # get workitems
     elif workitem:
@@ -262,27 +259,19 @@ def update(
         doc_title = doc_name
 
         # create document from string or html file
-        update_obj.update_document(
-            space, doc_name, doc_title, doc_wi_type, doc_type, "parent", doc_content
-        )
+        update_obj.update_document(space, doc_name, doc_title, doc_wi_type, doc_type, "parent", doc_content)
 
     elif run:
         if result:
             if testcase:
                 # update one case result for runs
-                update_obj.update_1_case_result_for_run(
-                    run, testcase, result, assignee, comment
-                )
+                update_obj.update_1_case_result_for_run(run, testcase, result, assignee, comment)
             else:
                 # update all case results for runs
-                update_obj.update_all_case_results_for_runs(
-                    run, result, assignee, comment
-                )
+                update_obj.update_all_case_results_for_runs(run, result, assignee, comment)
         else:
             # update/create runs
-            update_obj.update_runs(
-                run, template, plannedin, assignee, status, description
-            )
+            update_obj.update_runs(run, template, plannedin, assignee, status, description)
     else:
         click.echo("Please get usage: pylero-cmd update --help")
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import os
-
 from setuptools import setup
 
 with open("README.md", "r") as handle:
@@ -41,8 +39,6 @@ if __name__ == "__main__":
             "Topic :: Software Development :: Build Tools",
             "License :: OSI Approved :: MIT License",  # Again, pick a license
             "Programming Language :: Python :: 3",  # Specify which pyhton versions that you want to support
-            "Programming Language :: Python :: 3.8",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",

--- a/src/pylero/__init__.py
+++ b/src/pylero/__init__.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Pylero is a Python wrapper for the Polarion WSDL API. It implements the
 API in a native Python object oriented approach, using objects to wrap like

--- a/src/pylero/_compatible.py
+++ b/src/pylero/_compatible.py
@@ -1,9 +1,9 @@
 # flake8: noqa
 """
-    _compatible.py
+_compatible.py
 
-    This is a compatibility module that assists on keeping the pylero
-    Library compatible with python 2.x and python 3.x.
+This is a compatibility module that assists on keeping the pylero
+Library compatible with python 2.x and python 3.x.
 """
 
 try:

--- a/src/pylero/activity.py
+++ b/src/pylero/activity.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.text import Text

--- a/src/pylero/activity_comment.py
+++ b/src/pylero/activity_comment.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.text import Text

--- a/src/pylero/activity_custom_value.py
+++ b/src/pylero/activity_custom_value.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/activity_custom_value_entry.py
+++ b/src/pylero/activity_custom_value_entry.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.activity_custom_value import ActivityCustomValue
 from pylero.base_polarion import BasePolarion

--- a/src/pylero/activity_source.py
+++ b/src/pylero/activity_source.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/approval.py
+++ b/src/pylero/approval.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/attachment.py
+++ b/src/pylero/attachment.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.user import User

--- a/src/pylero/base_polarion.py
+++ b/src/pylero/base_polarion.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import base64
 import copy
@@ -12,9 +9,8 @@ from functools import wraps
 from getpass import getpass
 
 import suds
-from pylero._compatible import basestring
-from pylero._compatible import classmethod
-from pylero._compatible import ConfigParser
+
+from pylero._compatible import ConfigParser, basestring, classmethod
 from pylero.exceptions import PyleroLibException
 from pylero.server import Server
 
@@ -43,9 +39,9 @@ class Configuration(object):
         defaults = {"cachingpolicy": "0", "timeout": "120"}
         config = ConfigParser(defaults)
         # Check for existence of config file and config_section
-        if not config.read(
-            [self.GLOBAL_CONFIG, self.LOCAL_CONFIG, self.CURDIR_CONFIG]
-        ) or not config.has_section(self.CONFIG_SECTION):
+        if not config.read([self.GLOBAL_CONFIG, self.LOCAL_CONFIG, self.CURDIR_CONFIG]) or not config.has_section(
+            self.CONFIG_SECTION
+        ):
             # Check for mandatory environ variables if config file is not found
             if not all(
                 os.environ.get(item)
@@ -56,69 +52,44 @@ class Configuration(object):
                 )
             ) and not (
                 os.environ.get("POLARION_TOKEN")
-                or (
-                    os.environ.get("POLARION_USERNAME")
-                    and os.environ.get("POLARION_PASSWORD")
-                )
+                or (os.environ.get("POLARION_USERNAME") and os.environ.get("POLARION_PASSWORD"))
             ):
                 raise PyleroLibException(
                     "The config files/ENV vars do not "
                     "exist or are not of the correct "
                     "format. Valid files are: {0}, {1} "
-                    "or {2}".format(
-                        self.GLOBAL_CONFIG, self.LOCAL_CONFIG, self.CURDIR_CONFIG
-                    )
+                    "or {2}".format(self.GLOBAL_CONFIG, self.LOCAL_CONFIG, self.CURDIR_CONFIG)
                 )
-        self.server_url = os.environ.get("POLARION_URL") or config.get(
-            self.CONFIG_SECTION, "url"
-        )
-        self.repo = os.environ.get("POLARION_REPO") or config.get(
-            self.CONFIG_SECTION, "svn_repo"
-        )
-        self.user = os.environ.get("POLARION_USERNAME") or config.get(
-            self.CONFIG_SECTION, "user"
-        )
-        self.pwd = os.environ.get("POLARION_PASSWORD") or config.get(
-            self.CONFIG_SECTION, "password"
-        )
-        self.token = os.environ.get("POLARION_TOKEN") or config.get(
-            self.CONFIG_SECTION, "token"
-        )
+        self.server_url = os.environ.get("POLARION_URL") or config.get(self.CONFIG_SECTION, "url")
+        self.repo = os.environ.get("POLARION_REPO") or config.get(self.CONFIG_SECTION, "svn_repo")
+        self.user = os.environ.get("POLARION_USERNAME") or config.get(self.CONFIG_SECTION, "user")
+        self.pwd = os.environ.get("POLARION_PASSWORD") or config.get(self.CONFIG_SECTION, "password")
+        self.token = os.environ.get("POLARION_TOKEN") or config.get(self.CONFIG_SECTION, "token")
 
         try:
-            self.timeout = os.environ.get("POLARION_TIMEOUT") or config.get(
-                self.CONFIG_SECTION, "timeout"
-            )
+            self.timeout = os.environ.get("POLARION_TIMEOUT") or config.get(self.CONFIG_SECTION, "timeout")
         except Exception:
             self.timeout = config.defaults["timeout"]
 
         try:
             self.timeout = int(self.timeout)
         except ValueError:
-            raise PyleroLibException(
-                "The timeout value in the config" " file must be an integer"
-            )
-        self.proj = os.environ.get("POLARION_PROJECT") or config.get(
-            self.CONFIG_SECTION, "default_project"
-        )
+            raise PyleroLibException("The timeout value in the config" " file must be an integer")
+        self.proj = os.environ.get("POLARION_PROJECT") or config.get(self.CONFIG_SECTION, "default_project")
         try:
-            self.cert_path = os.environ.get("POLARION_CERT_PATH") or config.get(
-                self.CONFIG_SECTION, "cert_path"
-            )
+            self.cert_path = os.environ.get("POLARION_CERT_PATH") or config.get(self.CONFIG_SECTION, "cert_path")
         except Exception:
             self.cert_path = None
 
         if not (self.server_url and self.proj) and not (self.user or self.token):
             raise PyleroLibException(
-                "The config files must contain "
-                "valid values for: url, credentials and "
-                "default_project"
+                "The config files must contain " "valid values for: url, credentials and " "default_project"
             )
 
         try:
-            self.disable_manual_auth = os.environ.get(
-                "POLARION_DISABLE_MANUAL_AUTH"
-            ) or config.getboolean(self.CONFIG_SECTION, "disable_manual_auth")
+            self.disable_manual_auth = os.environ.get("POLARION_DISABLE_MANUAL_AUTH") or config.getboolean(
+                self.CONFIG_SECTION, "disable_manual_auth"
+            )
         except Exception:
             self.disable_manual_auth = False
 
@@ -145,7 +116,7 @@ class Connection(object):
     token_enabled = False
 
     @classmethod
-    def session(cls):
+    def session(cls):  # noqa: F811
         if not cls.connected:
             cfg = Configuration()
             # if the password is not supplied in the config file, ask the user
@@ -180,14 +151,9 @@ class Connection(object):
                     # If we couldn't connect its because the user has typed the
                     # wrong password. So we keep asking for password till we
                     # are successfully connected
-                    if (
-                        "com.polarion.platform.security."
-                        "AuthenticationFailedException" in e.fault.faultstring
-                    ):
+                    if "com.polarion.platform.security." "AuthenticationFailedException" in e.fault.faultstring:
                         if cfg.disable_manual_auth:
-                            raise PyleroLibException(
-                                "Manual authentication " "is disabled"
-                            )
+                            raise PyleroLibException("Manual authentication " "is disabled")
                         if cls.token_enabled:
                             cfg.token = getpass("Invalid Token.\nEnter Token:")
                         else:
@@ -196,10 +162,7 @@ class Connection(object):
                     else:
                         raise
             if not cls.retries:
-                raise PyleroLibException(
-                    "Unable to establish pylero session "
-                    "due to 3 incorrect login attempts"
-                )
+                raise PyleroLibException("Unable to establish pylero session " "due to 3 incorrect login attempts")
             cls.session.default_project = cfg.proj
             # TODO: Update user from query with token owner
             cls.session.user_id = cfg.user
@@ -334,8 +297,7 @@ class BasePolarion(object):
                 % (
                     (
                         "customFields."
-                        if isinstance(cls._cls_suds_map[x], dict)
-                        and cls._cls_suds_map[x].get("is_custom", False)
+                        if isinstance(cls._cls_suds_map[x], dict) and cls._cls_suds_map[x].get("is_custom", False)
                         else ""
                     ),
                     (
@@ -380,9 +342,7 @@ class BasePolarion(object):
         References:
             Security.hasCurrentUserPermission
         """
-        return cls.session.security_client.service.hasCurrentuserPermission(
-            permission, project_id
-        )
+        return cls.session.security_client.service.hasCurrentuserPermission(permission, project_id)
 
     def __init__(self, obj_id=None, suds_object=None):
         # cls_suds_map must be available for some parameters on the class
@@ -399,11 +359,7 @@ class BasePolarion(object):
         # if _id_field has not been set in the child class, the obj_id field
         # cannot be passed as a parameter.
         if obj_id and not self._id_field:
-            raise PyleroLibException(
-                "{0} only accepts a suds object, not an obj_id".format(
-                    self.__class__.__name
-                )
-            )
+            raise PyleroLibException("{0} only accepts a suds object, not an obj_id".format(self.__class__.__name))
         if suds_object:
             self._suds_object = suds_object
         else:
@@ -443,12 +399,8 @@ class BasePolarion(object):
                             self.__class__,
                             key,
                             property(
-                                lambda self, field_name=key: self._custom_getter(
-                                    field_name
-                                ),
-                                lambda self, val, field_name=key: self._custom_setter(
-                                    val, field_name
-                                ),
+                                lambda self, field_name=key: self._custom_getter(field_name),
+                                lambda self, val, field_name=key: self._custom_setter(val, field_name),
                             ),
                         )
                     elif "is_array" in self._cls_suds_map[key]:
@@ -456,12 +408,8 @@ class BasePolarion(object):
                             self.__class__,
                             key,
                             property(
-                                lambda self, field_name=key: self._arr_obj_getter(
-                                    field_name
-                                ),
-                                lambda self, val, field_name=key: self._arr_obj_setter(
-                                    val, field_name
-                                ),
+                                lambda self, field_name=key: self._arr_obj_getter(field_name),
+                                lambda self, val, field_name=key: self._arr_obj_setter(val, field_name),
                             ),
                         )
                     else:
@@ -469,12 +417,8 @@ class BasePolarion(object):
                             self.__class__,
                             key,
                             property(
-                                lambda self, field_name=key: self._obj_getter(
-                                    field_name
-                                ),
-                                lambda self, val, field_name=key: self._obj_setter(
-                                    val, field_name
-                                ),
+                                lambda self, field_name=key: self._obj_getter(field_name),
+                                lambda self, val, field_name=key: self._obj_setter(val, field_name),
                             ),
                         )
                 else:
@@ -484,12 +428,8 @@ class BasePolarion(object):
                         property(
                             # if the attribute doesn't exist in the current object
                             # return None
-                            lambda self, suds_key=self._cls_suds_map[key]: getattr(
-                                self._suds_object, suds_key, None
-                            ),
-                            lambda self, value, suds_key=self._cls_suds_map[
-                                key
-                            ]: self._regular_setter(value, suds_key),
+                            lambda self, suds_key=self._cls_suds_map[key]: getattr(self._suds_object, suds_key, None),
+                            lambda self, value, suds_key=self._cls_suds_map[key]: self._regular_setter(value, suds_key),
                         ),
                     )
         # after all properties are defined set the id field to the value passed in.
@@ -499,9 +439,7 @@ class BasePolarion(object):
     def _get_suds_object(self):
         """Returns the WSDL object as created by the Polarion WSDL factory"""
         if self._obj_client and self._obj_struct:
-            self._suds_object = getattr(self.session, self._obj_client).factory.create(
-                self._obj_struct
-            )
+            self._suds_object = getattr(self.session, self._obj_client).factory.create(self._obj_struct)
         else:
             self._suds_object = None
 
@@ -621,9 +559,7 @@ class BasePolarion(object):
         arr_inst = csm.get("arr_cls")()
         obj_inst = csm.get("cls")()
         # obj_attach =
-        if not isinstance(
-            val, (list, arr_inst.__class__, arr_inst._suds_object.__class__)
-        ):
+        if not isinstance(val, (list, arr_inst.__class__, arr_inst._suds_object.__class__)):
             raise PyleroLibException("{0}s must be a list of {1}").format(
                 csm["field_name"], obj_inst.__class__.__name__
             )
@@ -686,9 +622,7 @@ class BasePolarion(object):
                 if test_steps:
                     return test_steps
         else:
-            if ("customFields" not in self._suds_object) or (
-                not self._suds_object.customFields
-            ):
+            if ("customFields" not in self._suds_object) or (not self._suds_object.customFields):
                 self._suds_object.customFields = self.custom_array_obj()
             cf = self._suds_object.customFields[0]
             custom_fld = None
@@ -741,9 +675,7 @@ class BasePolarion(object):
             elif isinstance(val, csm["cls"]()._suds_object.__class__):
                 self._changed_fields[csm["field_name"]] = val
             else:
-                raise PyleroLibException(
-                    "The value must be a {0}".format(csm["cls"].__name__)
-                )
+                raise PyleroLibException("The value must be a {0}".format(csm["cls"].__name__))
         # move the custom fields to within the object, otherwise each custom
         # field is a seperate SVN commit. testSteps, does not work unless it
         # is uploaded using the set_test_steps function.
@@ -752,9 +684,7 @@ class BasePolarion(object):
             cust.key = csm["field_name"]
             if val is None:
                 cust.value = None
-            elif (not csm.get("cls") or isinstance(val, basestring)) and not csm.get(
-                "is_array"
-            ):
+            elif (not csm.get("cls") or isinstance(val, basestring)) and not csm.get("is_array"):
                 # if there is no cls specified, val can be a bool, int, ...
                 # if val is a string, it may be used to instantiate the class
                 if isinstance(val, basestring):
@@ -762,9 +692,7 @@ class BasePolarion(object):
                 if csm.get("enum_id") and val not in csm.get("enum_override", []):
                     # uses deepcopy, to not affect other instances of the class
                     additional_parms = copy.deepcopy(csm.get("additional_parms", {}))
-                    self.check_valid_field_values(
-                        val, csm.get("enum_id"), additional_parms, csm.get("control")
-                    )
+                    self.check_valid_field_values(val, csm.get("enum_id"), additional_parms, csm.get("control"))
                 cust.value = csm["cls"](val)._suds_object if csm.get("cls") else val
             elif csm.get("is_array"):
                 if not isinstance(val, list):
@@ -775,9 +703,7 @@ class BasePolarion(object):
                         if i not in csm.get("enum_override", []):
                             # uses deepcopy, to not affect other instances
                             # of the class
-                            additional_parms = copy.deepcopy(
-                                csm.get("additional_parms", {})
-                            )
+                            additional_parms = copy.deepcopy(csm.get("additional_parms", {}))
                             self.check_valid_field_values(
                                 i,
                                 csm.get("enum_id"),
@@ -791,12 +717,8 @@ class BasePolarion(object):
             elif isinstance(val, csm["cls"]()._suds_object.__class__):
                 cust.value = val
             else:
-                raise PyleroLibException(
-                    "The value must be of type {0}.".format(csm["cls"].__name__)
-                )
-            if ("customFields" not in self._suds_object) or (
-                not self._suds_object.customFields
-            ):
+                raise PyleroLibException("The value must be of type {0}.".format(csm["cls"].__name__))
+            if ("customFields" not in self._suds_object) or (not self._suds_object.customFields):
                 self._suds_object.customFields = self.custom_array_obj()
             cf = self._suds_object.customFields[0]
             if cf:
@@ -871,9 +793,7 @@ class BasePolarion(object):
         # checking if the uri field is populated. If no URI it didn't come from
         # the server
         if not getattr(self, "uri", None):
-            raise PyleroLibException(
-                "There is no {0} loaded".format(self.__class__.__name__)
-            )
+            raise PyleroLibException("There is no {0} loaded".format(self.__class__.__name__))
 
     def can_add_element_to_key(self, key):
         """Checks if the current user can add elements to the collection at
@@ -982,9 +902,7 @@ class BasePolarion(object):
             Security.canRemoveElementFromKey
         """
         self._verify_obj()
-        return self.session.security_client.service.canRemoveElementFromKey(
-            self.uri, key
-        )
+        return self.session.security_client.service.canRemoveElementFromKey(self.uri, key)
 
     def get_location(self):
         """Returns the location of the current object. In the context of this
@@ -1022,15 +940,11 @@ class BasePolarion(object):
                 # parms. If that works, it is a valid value
                 enum_id(val, **additional_parms)
             except Exception:
-                raise PyleroLibException(
-                    "{0} is not a valid value for {1}".format(val, enum_id.__name__)
-                )
+                raise PyleroLibException("{0} is not a valid value for {1}".format(val, enum_id.__name__))
         else:
             valid_values = self.get_valid_field_values(enum_id, control)
             if val not in valid_values:
-                raise PyleroLibException(
-                    "Acceptable values for {0} are:" "{1}".format(enum_id, valid_values)
-                )
+                raise PyleroLibException("Acceptable values for {0} are:" "{1}".format(enum_id, valid_values))
 
     def get_valid_field_values(self, enum_id, control=None):
         """Gets the available enumeration options.
@@ -1053,9 +967,7 @@ class BasePolarion(object):
         if enum_base:
             enums = enum_base.get(control)
         if not enums:
-            enums = self.session.tracker_client.service.getEnumOptionsForIdWithControl(
-                project_id, enum_id, control
-            )
+            enums = self.session.tracker_client.service.getEnumOptionsForIdWithControl(project_id, enum_id, control)
             self._cache["enums"][enum_id] = {}
             self._cache["enums"][enum_id][control] = enums
         # the _cache contains _suds_object, so the id attribute is used.
@@ -1087,9 +999,7 @@ class BasePolarion(object):
         Returns:
             a Revision object
         """
-        return self.session.tracker_client.service.getrevision(
-            repository_name, revision_id
-        )
+        return self.session.tracker_client.service.getrevision(repository_name, revision_id)
 
     def get_revision_by_uri(self, revision_uri):
         """

--- a/src/pylero/baseline.py
+++ b/src/pylero/baseline.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.project import Project
@@ -50,9 +47,7 @@ class Baseline(BasePolarion):
         References:
             Tracker.createBaseline
         """
-        suds_object = cls.session.tracker_client.service.createBaseline(
-            project_id, name, description, revision
-        )
+        suds_object = cls.session.tracker_client.service.createBaseline(project_id, name, description, revision)
         return cls(suds_object=suds_object)
 
     @classmethod

--- a/src/pylero/build.py
+++ b/src/pylero/build.py
@@ -1,12 +1,8 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.build_linked_work_item import ArrayOfBuildLinkedWorkItem
-from pylero.build_linked_work_item import BuildLinkedWorkItem
+from pylero.build_linked_work_item import ArrayOfBuildLinkedWorkItem, BuildLinkedWorkItem
 from pylero.build_test_results import BuildTestResults
 from pylero.user import User
 

--- a/src/pylero/build_linked_work_item.py
+++ b/src/pylero/build_linked_work_item.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/build_test_results.py
+++ b/src/pylero/build_test_results.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/category.py
+++ b/src/pylero/category.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.text import Text

--- a/src/pylero/change.py
+++ b/src/pylero/change.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/cli/cmd.py
+++ b/src/pylero/cli/cmd.py
@@ -4,13 +4,11 @@ from __future__ import print_function
 import datetime
 import os
 
-from pylero._compatible import object
-from pylero._compatible import str
+from pylero._compatible import object, str
 from pylero.document import Document
 from pylero.plan import Plan
 from pylero.test_run import TestRun
-from pylero.work_item import Requirement
-from pylero.work_item import TestCase
+from pylero.work_item import Requirement, TestCase
 
 
 class CmdList(object):
@@ -34,10 +32,7 @@ class CmdList(object):
         print("-------%7s------%7s--------" % ("", ""))
 
         for doc in docs:
-            print(
-                "%-14s %-11s %s"
-                % (doc.created.strftime("%Y-%m-%d"), doc.author, doc.document_id)
-            )
+            print("%-14s %-11s %s" % (doc.created.strftime("%Y-%m-%d"), doc.author, doc.document_id))
 
     def list_workitems_in_doc(self, doc_name_with_space):
         if doc_name_with_space.find("/") < 0:
@@ -69,9 +64,7 @@ class CmdList(object):
 
         for wi in workitems:
             created = str(wi.created).split(" ")[0]
-            print(
-                "%-13s %-13s %-13s %s" % (created, wi.type, wi.work_item_id, wi.title)
-            )
+            print("%-13s %-13s %-13s %s" % (created, wi.type, wi.work_item_id, wi.title))
 
     def list_workitems_by_query(self, query, wi_type):
         fields = ["work_item_id", "title", "author", "created"]
@@ -81,9 +74,7 @@ class CmdList(object):
         elif wi_type in ["requirement", "Requirement"]:
             workitem_list = Requirement.query(query, fields)
         elif wi_type == "":
-            workitem_list = TestCase.query(query, fields) + Requirement.query(
-                query, fields
-            )
+            workitem_list = TestCase.query(query, fields) + Requirement.query(query, fields)
         else:
             print("'%s' is invalid. Use testcase or requirement" % wi_type)
             exit(0)
@@ -173,15 +164,10 @@ class CmdList(object):
 
         for rec in tr.records:
             time = str(rec.executed).split(".")[0]
-            print(
-                "%-21s%-9s%-12s%-10s"
-                % (time, rec.result, rec.executed_by, rec.test_case_id)
-            )
+            print("%-21s%-9s%-12s%-10s" % (time, rec.result, rec.executed_by, rec.test_case_id))
 
     def print_plan_ids(self, query):
-        pls = Plan.search(
-            query, sort="due_date", limit=-1, fields=["due_date", "name", "plan_id"]
-        )
+        pls = Plan.search(query, sort="due_date", limit=-1, fields=["due_date", "name", "plan_id"])
 
         ttstr = "Due Date%-5sPlan ID%-24sPlan Name" % ("", "")
         lnstr = "-----------  ---------- %-20s---------" % ""
@@ -248,10 +234,7 @@ class CmdUpdate(object):
                 rec.comment = comment
 
                 tr.update_test_record_by_object(testcase, rec)
-                print(
-                    "%4sSet %s to %s (verdict comment: '%s')"
-                    % ("", testcase, result, comment)
-                )
+                print("%4sSet %s to %s (verdict comment: '%s')" % ("", testcase, result, comment))
                 return 0
 
         if not is_found:

--- a/src/pylero/comment.py
+++ b/src/pylero/comment.py
@@ -1,15 +1,10 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.enum_option_id import ArrayOfEnumOptionId
-from pylero.enum_option_id import EnumOptionId
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId
 from pylero.signature_data import SignatureData
-from pylero.subterra_uri import ArrayOfSubterraURI
-from pylero.subterra_uri import SubterraURI
+from pylero.subterra_uri import ArrayOfSubterraURI, SubterraURI
 from pylero.text import Text
 from pylero.user import User
 

--- a/src/pylero/custom.py
+++ b/src/pylero/custom.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/custom_field.py
+++ b/src/pylero/custom_field.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/custom_field_type.py
+++ b/src/pylero/custom_field_type.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/document.py
+++ b/src/pylero/document.py
@@ -1,25 +1,18 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import base64
 
 import suds
+
 from pylero._compatible import basestring
-from pylero.base_polarion import BasePolarion
-from pylero.base_polarion import tx_wrapper
-from pylero.custom import ArrayOfCustom
-from pylero.custom import Custom
-from pylero.enum_option_id import ArrayOfEnumOptionId
-from pylero.enum_option_id import EnumOptionId
+from pylero.base_polarion import BasePolarion, tx_wrapper
+from pylero.custom import ArrayOfCustom, Custom
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId
 from pylero.exceptions import PyleroLibException
-from pylero.module_comment import ArrayOfModuleComment
-from pylero.module_comment import ModuleComment
+from pylero.module_comment import ArrayOfModuleComment, ModuleComment
 from pylero.project import Project
-from pylero.signature_context import ArrayOfSignatureContext
-from pylero.signature_context import SignatureContext
+from pylero.signature_context import ArrayOfSignatureContext, SignatureContext
 from pylero.subterra_uri import SubterraURI
 from pylero.text import Text
 from pylero.user import User
@@ -130,10 +123,7 @@ class Document(BasePolarion):
     _obj_struct = "tns4:Module"
     # The uri struct of a module is different then others because of extra
     # moduleFolder element. Also requires a substitution from # to / and back
-    URI_STRUCT = (
-        "subterra:data-service:objects:/default/"
-        "%(project)s${%(obj)s}{moduleFolder}%(id)s"
-    )
+    URI_STRUCT = "subterra:data-service:objects:/default/" "%(project)s${%(obj)s}{moduleFolder}%(id)s"
     # must wrap lambda with classmethod so it can be used as such
     URI_ID_GET_REPLACE = classmethod(lambda cls, x: x.replace("#", "/"))
     URI_ID_SET_REPLACE = classmethod(lambda cls, x: x.replace("/", "#"))
@@ -207,9 +197,7 @@ class Document(BasePolarion):
             return doc
         except suds.WebFault as e:
             if "Invalid document on location Location" in e.fault.faultstring:
-                raise PyleroLibException(
-                    "Document {0}/{1} already exists".format(space, document_name)
-                )
+                raise PyleroLibException("Document {0}/{1} already exists".format(space, document_name))
             else:
                 raise PyleroLibException(e.fault)
 
@@ -239,9 +227,7 @@ class Document(BasePolarion):
         if p_fields:
             function_name += "WithFields"
             parms += [p_fields]
-        for suds_module in getattr(cls.session.tracker_client.service, function_name)(
-            *parms
-        ):
+        for suds_module in getattr(cls.session.tracker_client.service, function_name)(*parms):
             docs.append(cls(suds_object=suds_module))
         return docs
 
@@ -345,9 +331,7 @@ class Document(BasePolarion):
         if output_name == "":
             output_name = uri.split("/")[-1]
 
-        base64_output = getattr(cls.session.tracker_client.service, function_name)(
-            *parms
-        )
+        base64_output = getattr(cls.session.tracker_client.service, function_name)(*parms)
         binary_data = base64.b64decode(base64_output)
 
         with open(f"{output_dir}/{output_name}.pdf", "wb") as file:
@@ -398,13 +382,9 @@ class Document(BasePolarion):
             if fields:
                 function_name = "WithFields"
                 parms.append(self._convert_obj_fields_to_polarion(fields))
-            self._suds_object = getattr(
-                self.session.tracker_client.service, function_name
-            )(*parms)
+            self._suds_object = getattr(self.session.tracker_client.service, function_name)(*parms)
             if getattr(self._suds_object, "_unresolvable", True):
-                raise PyleroLibException(
-                    "The Document {0} was not found.".format(doc_with_space or uri)
-                )
+                raise PyleroLibException("The Document {0} was not found.".format(doc_with_space or uri))
 
     def _fix_circular_refs(self):
         # a class can't reference itself as a class attribute.
@@ -432,18 +412,14 @@ class Document(BasePolarion):
         else:
             raise PyleroLibException("the w_item parameter must be a _WorkItem")
         if parent_id:
-            parent_uri = _WorkItem(
-                work_item_id=parent_id, project_id=self.project_id
-            ).uri
+            parent_uri = _WorkItem(work_item_id=parent_id, project_id=self.project_id).uri
         else:
             doc_wis = self.get_work_items(None, False)
             if doc_wis:
                 parent_uri = doc_wis[0].uri
             else:
                 parent_uri = None
-        wi_uri = self.session.tracker_client.service.createWorkItemInModule(
-            self.uri, parent_uri, suds_wi
-        )
+        wi_uri = self.session.tracker_client.service.createWorkItemInModule(self.uri, parent_uri, suds_wi)
         new_wi = w_item.__class__(uri=wi_uri)
         new_wi._changed_fields = w_item._changed_fields
         new_wi.update()
@@ -462,9 +438,7 @@ class Document(BasePolarion):
         self._verify_obj()
         self.session.tracker_client.service.deleteModule(self.uri)
 
-    def get_work_items(
-        self, parent_work_item_id, deep, fields=["work_item_id", "type"]
-    ):
+    def get_work_items(self, parent_work_item_id, deep, fields=["work_item_id", "type"]):
         """Returns work items (with given fields set) contained in given
         Module/Document under given parent (if specified).
 
@@ -483,9 +457,7 @@ class Document(BasePolarion):
         """
         self._verify_obj()
         if parent_work_item_id:
-            parent_uri = _WorkItem(
-                work_item_id=parent_work_item_id, project_id=self.project_id
-            ).uri
+            parent_uri = _WorkItem(work_item_id=parent_work_item_id, project_id=self.project_id).uri
         else:
             parent_uri = None
         p_fields = list()
@@ -495,17 +467,13 @@ class Document(BasePolarion):
             filtered_fields = [f for f in fields if f in wi_type._cls_suds_map.keys()]
             p_fields.extend(wi_type._convert_obj_fields_to_polarion(filtered_fields))
         p_fields = list(set(p_fields))
-        suds_wi = self.session.tracker_client.service.getModuleWorkItems(
-            self.uri, parent_uri, deep, p_fields
-        )
+        suds_wi = self.session.tracker_client.service.getModuleWorkItems(self.uri, parent_uri, deep, p_fields)
         work_items = []
         for w_item in suds_wi:
             work_items.append(_WorkItem(suds_object=w_item))
         return work_items
 
-    def move_work_item_here(
-        self, work_item_id, parent_id, position=-1, retain_flow=True
-    ):
+    def move_work_item_here(self, work_item_id, parent_id, position=-1, retain_flow=True):
         """Moves a work item to a specific position in a Document. If the work
         item is not yet inside the Document it will be moved into the Document.
 
@@ -534,9 +502,7 @@ class Document(BasePolarion):
             parent_uri = _WorkItem(self.project_id, parent_id).uri
         else:
             parent_uri = None
-        self.session.tracker_client.service.moveWorkItemToDocument(
-            wi.uri, self.uri, parent_uri, position, retain_flow
-        )
+        self.session.tracker_client.service.moveWorkItemToDocument(wi.uri, self.uri, parent_uri, position, retain_flow)
 
     def add_referenced_work_item(self, work_item_id):
         """Adds a work item to the document as a referenced work_item to the
@@ -552,10 +518,7 @@ class Document(BasePolarion):
         self._verify_obj()
         # verify that the work item passed in exists
         _WorkItem(project_id=self.project_id, work_item_id=work_item_id)
-        ref_wi_template = (
-            """<div id="polarion_wiki macro name="""
-            """module-workitem;params=id=%s|external=true">"""
-        )
+        ref_wi_template = """<div id="polarion_wiki macro name=""" """module-workitem;params=id=%s|external=true">"""
         self.home_page_content += ref_wi_template % work_item_id
         self.update()
 

--- a/src/pylero/enum_custom_field_type.py
+++ b/src/pylero/enum_custom_field_type.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/enum_option.py
+++ b/src/pylero/enum_option.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.properties import Properties

--- a/src/pylero/enum_option_id.py
+++ b/src/pylero/enum_option_id.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/exceptions.py
+++ b/src/pylero/exceptions.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 class PyleroLibException(Exception):

--- a/src/pylero/externally_linked_work_item.py
+++ b/src/pylero/externally_linked_work_item.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId
@@ -42,9 +39,7 @@ class ExternallyLinkedWorkItem(BasePolarion):
         from pylero.work_item import _WorkItem
 
         self._cls_suds_map["work_item_id"]["cls"] = _WorkItem
-        self._cls_suds_map["work_item_id"]["additional_parms"] = {
-            "project_id": self.project_id
-        }
+        self._cls_suds_map["work_item_id"]["additional_parms"] = {"project_id": self.project_id}
 
 
 class ArrayOfExternallyLinkedWorkItem(BasePolarion):

--- a/src/pylero/field_diff.py
+++ b/src/pylero/field_diff.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/hyperlink.py
+++ b/src/pylero/hyperlink.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/imported_comment.py
+++ b/src/pylero/imported_comment.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/language_definition.py
+++ b/src/pylero/language_definition.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/license_info.py
+++ b/src/pylero/license_info.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/linked_work_item.py
+++ b/src/pylero/linked_work_item.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId
@@ -46,9 +43,7 @@ class LinkedWorkItem(BasePolarion):
         from pylero.work_item import _WorkItem
 
         self._cls_suds_map["work_item_id"]["cls"] = _WorkItem
-        self._cls_suds_map["work_item_id"]["additional_parms"] = {
-            "project_id": self.project_id
-        }
+        self._cls_suds_map["work_item_id"]["additional_parms"] = {"project_id": self.project_id}
 
 
 class ArrayOfLinkedWorkItem(BasePolarion):

--- a/src/pylero/module_comment.py
+++ b/src/pylero/module_comment.py
@@ -1,16 +1,11 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.enum_option_id import ArrayOfEnumOptionId
-from pylero.enum_option_id import EnumOptionId
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId
 from pylero.imported_comment import ImportedComment
 from pylero.signature_data import SignatureData
-from pylero.subterra_uri import ArrayOfSubterraURI
-from pylero.subterra_uri import SubterraURI
+from pylero.subterra_uri import ArrayOfSubterraURI, SubterraURI
 from pylero.text import Text
 from pylero.user import User
 

--- a/src/pylero/plan.py
+++ b/src/pylero/plan.py
@@ -1,19 +1,14 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import suds
+
 from pylero._compatible import basestring
 from pylero.base_polarion import BasePolarion
-from pylero.custom import ArrayOfCustom
-from pylero.custom import Custom
-from pylero.enum_option_id import ArrayOfEnumOptionId
-from pylero.enum_option_id import EnumOptionId
+from pylero.custom import ArrayOfCustom, Custom
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId
 from pylero.exceptions import PyleroLibException
-from pylero.plan_record import ArrayOfPlanRecord
-from pylero.plan_record import PlanRecord
+from pylero.plan_record import ArrayOfPlanRecord, PlanRecord
 from pylero.plan_statistics import PlanStatistics
 from pylero.project import Project
 from pylero.subterra_uri import SubterraURI
@@ -141,9 +136,7 @@ class Plan(BasePolarion):
         References:
             Planning.createPlan
         """
-        uri = cls.session.planning_client.service.createPlan(
-            project_id, plan_name, plan_id, parent_id, template_id
-        )
+        uri = cls.session.planning_client.service.createPlan(project_id, plan_name, plan_id, parent_id, template_id)
         return Plan(uri=uri)
 
     @classmethod
@@ -163,9 +156,7 @@ class Plan(BasePolarion):
         References:
             Planning.createPlanTemplate
         """
-        uri = cls.session.planning_client.service.createPlanTemplate(
-            project_id, template_name, template_id, parent_id
-        )
+        uri = cls.session.planning_client.service.createPlanTemplate(project_id, template_name, template_id, parent_id)
         return Plan(uri=uri)
 
     @classmethod
@@ -216,13 +207,9 @@ class Plan(BasePolarion):
             if not isinstance(cls._cls_suds_map[sort], dict)
             else cls._cls_suds_map[sort]["field_name"]
         )
-        parms = [query, p_sort, limit] + (
-            [cls._convert_obj_fields_to_polarion(fields)] if fields else []
-        )
+        parms = [query, p_sort, limit] + ([cls._convert_obj_fields_to_polarion(fields)] if fields else [])
         plans = []
-        for sud_plan in getattr(cls.session.planning_client.service, function_name)(
-            *parms
-        ):
+        for sud_plan in getattr(cls.session.planning_client.service, function_name)(*parms):
             plans.append(Plan(suds_object=sud_plan))
         return plans
 
@@ -246,12 +233,8 @@ class Plan(BasePolarion):
         super(self.__class__, self).__init__(obj_id=plan_id, suds_object=suds_object)
         if plan_id:
             if not project_id:
-                raise PyleroLibException(
-                    "When plan_id is passed in, " "project_id is required"
-                )
-            self._suds_object = self.session.planning_client.service.getPlanById(
-                project_id, plan_id
-            )
+                raise PyleroLibException("When plan_id is passed in, " "project_id is required")
+            self._suds_object = self.session.planning_client.service.getPlanById(project_id, plan_id)
         elif uri:
             self._suds_object = self.session.planning_client.service.getPlanByUri(uri)
         if plan_id or uri:
@@ -281,9 +264,7 @@ class Plan(BasePolarion):
         self._verify_obj()
         if work_items:
             if not isinstance(work_items, list):
-                raise PyleroLibException(
-                    "work_items must be a list of _WorkItem objects"
-                )
+                raise PyleroLibException("work_items must be a list of _WorkItem objects")
         p_items = []
         for item in work_items:
             wi = _WorkItem(self.project_id, work_item_id=item)
@@ -337,9 +318,7 @@ class Plan(BasePolarion):
         self._verify_obj()
         if work_items:
             if not isinstance(work_items, list):
-                raise PyleroLibException(
-                    "work_items must be a list of _WorkItem objects"
-                )
+                raise PyleroLibException("work_items must be a list of _WorkItem objects")
         p_items = []
         for item in work_items:
             wi = _WorkItem(self.project_id, work_item_id=item)

--- a/src/pylero/plan_record.py
+++ b/src/pylero/plan_record.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.work_item import _WorkItem

--- a/src/pylero/plan_statistics.py
+++ b/src/pylero/plan_statistics.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/planning_constraint.py
+++ b/src/pylero/planning_constraint.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/priority_opt.py
+++ b/src/pylero/priority_opt.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.properties import Properties

--- a/src/pylero/priority_option_id.py
+++ b/src/pylero/priority_option_id.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/product_license.py
+++ b/src/pylero/product_license.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/project.py
+++ b/src/pylero/project.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 
@@ -101,14 +98,10 @@ class Project(BasePolarion):
             if project:
                 self._suds_object = copy.deepcopy(project)
             else:
-                self._suds_object = self.session.project_client.service.getProject(
-                    project_id
-                )
+                self._suds_object = self.session.project_client.service.getProject(project_id)
                 self._cache["projects"][project_id] = self._suds_object
         elif location:
-            self._suds_object = (
-                self.session.project_client.service.getProjectAtLocation(location)
-            )
+            self._suds_object = self.session.project_client.service.getProjectAtLocation(location)
         elif uri:
             self._suds_object = self.session.project_client.service.getProjectByURI(uri)
         if project_id or location or uri:
@@ -136,9 +129,7 @@ class Project(BasePolarion):
         """
         self._verify_obj()
         categories = []
-        for suds_cat in self.session.tracker_client.service.getCategories(
-            self.project_id
-        ):
+        for suds_cat in self.session.tracker_client.service.getCategories(self.project_id):
             categories.append(Category(suds_object=suds_cat))
         return categories
 
@@ -155,9 +146,7 @@ class Project(BasePolarion):
             Tracker.getDefinedCustomFieldkeys
         """
         self._verify_obj()
-        return self.session.tracker_client.service.getDefinedCustomFieldkeys(
-            self.project_id, work_item_type_id
-        )
+        return self.session.tracker_client.service.getDefinedCustomFieldkeys(self.project_id, work_item_type_id)
 
     def get_defined_custom_field_type(self, work_item_type_id, key):
         """method get_defined_custom_field_type gets custom field definition
@@ -194,9 +183,7 @@ class Project(BasePolarion):
         """
         self._verify_obj()
         customs = []
-        for (
-            suds_custom
-        ) in self.session.tracker_client.service.getDefinedCustomFieldType(
+        for suds_custom in self.session.tracker_client.service.getDefinedCustomFieldType(
             self.project_id, work_item_type_id
         ):
             customs.append(CustomFieldType(suds_object=suds_custom))
@@ -231,9 +218,7 @@ class Project(BasePolarion):
         """
         self._verify_obj()
         users = []
-        for suds_user in self.session.project_client.service.getProjectUsers(
-            self.project_id
-        ):
+        for suds_user in self.session.project_client.service.getProjectUsers(self.project_id):
             users.append(User(suds_object=suds_user))
 
     def get_test_steps_configuration(self):
@@ -250,11 +235,7 @@ class Project(BasePolarion):
             TestManagement.getTestStepsConfiguration
         """
         self._verify_obj()
-        config_steps = (
-            self.session.test_management_client.service.getTestStepsConfiguration(
-                self.project_id
-            )
-        )
+        config_steps = self.session.test_management_client.service.getTestStepsConfiguration(self.project_id)
         return config_steps[0]
 
     def get_tests_configuration(self):
@@ -271,11 +252,7 @@ class Project(BasePolarion):
             TestManagement.getTestsConfiguration
         """
         self._verify_obj()
-        tests_config = (
-            self.session.test_management_client.service.getTestsConfiguration(
-                self.project_id
-            )
-        )
+        tests_config = self.session.test_management_client.service.getTestsConfiguration(self.project_id)
         return TestsConfiguration(suds_object=tests_config)
 
     def get_wiki_spaces(self):

--- a/src/pylero/project_group.py
+++ b/src/pylero/project_group.py
@@ -1,13 +1,9 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.project import Project
-from pylero.subterra_uri import ArrayOfSubterraURI
-from pylero.subterra_uri import SubterraURI
+from pylero.subterra_uri import ArrayOfSubterraURI, SubterraURI
 
 
 class ProjectGroup(BasePolarion):
@@ -75,9 +71,7 @@ class ProjectGroup(BasePolarion):
         if uri:
             self._suds_object = self.session.project_client.service.getProjectGroup(uri)
         elif location:
-            self._suds_object = (
-                self.session.project_client.service.getProjectGroupAtLocation(location)
-            )
+            self._suds_object = self.session.project_client.service.getProjectGroupAtLocation(location)
 
     def get_contained_groups(self):
         """Gets all project groups located directly below the project group.
@@ -93,9 +87,7 @@ class ProjectGroup(BasePolarion):
         """
         self._verify_obj()
         groups = []
-        for suds_group in self.session.project_client.service.getContainedGroups(
-            self.uri
-        ):
+        for suds_group in self.session.project_client.service.getContainedGroups(self.uri):
             groups.append(self.__class__(suds_object=suds_group))
         return groups
 
@@ -113,9 +105,7 @@ class ProjectGroup(BasePolarion):
         """
         self._verify_obj()
         projects = []
-        for suds_project in self.session.project_client.service.getContainedProjects(
-            self.uri
-        ):
+        for suds_project in self.session.project_client.service.getContainedProjects(self.uri):
             projects.append(Project(suds_object=suds_project))
         return projects
 
@@ -133,8 +123,6 @@ class ProjectGroup(BasePolarion):
         """
         self._verify_obj()
         projects = []
-        for (
-            suds_project
-        ) in self.session.project_client.service.getDeepContainedProjects(self.uri):
+        for suds_project in self.session.project_client.service.getDeepContainedProjects(self.uri):
             projects.append(Project(suds_object=suds_project))
         return projects

--- a/src/pylero/properties.py
+++ b/src/pylero/properties.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/property.py
+++ b/src/pylero/property.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/revision.py
+++ b/src/pylero/revision.py
@@ -1,12 +1,8 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.subterra_uri import ArrayOfSubterraURI
-from pylero.subterra_uri import SubterraURI
+from pylero.subterra_uri import ArrayOfSubterraURI, SubterraURI
 
 
 class Revision(BasePolarion):
@@ -67,13 +63,9 @@ class Revision(BasePolarion):
             Tracker.queryRevisions
         """
         if query_uris:
-            return cls.session.tracker_client.service.queryRevisionUris(
-                query, sort, False
-            )
+            return cls.session.tracker_client.service.queryRevisionUris(query, sort, False)
         else:
-            revs = cls.session.tracker_client.service.queryRevisions(
-                query, sort, fields
-            )
+            revs = cls.session.tracker_client.service.queryRevisions(query, sort, fields)
             lst_rev = [Revision(suds_object=rev) for rev in revs]
             return lst_rev
 

--- a/src/pylero/server.py
+++ b/src/pylero/server.py
@@ -1,10 +1,6 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pylero._compatible import builtins  # noqa
 from pylero._compatible import object
 from pylero.session import Session
 

--- a/src/pylero/session.py
+++ b/src/pylero/session.py
@@ -100,6 +100,14 @@ class Session(object):
         self._last_request_at = None
         self._session_id_header = None
         self._cookies = None
+
+        # This block forces ssl certificate verification
+        # Must be set BEFORE creating any WSDL clients (fixes #185)
+        if self._server.cert_path:
+            global CERT_PATH
+            CERT_PATH = self._server.cert_path
+            ssl._create_default_https_context = create_ssl_context
+
         self._session_client = _SudsClientWrapper(
             self._url_for_name("Session"), None, timeout
         )
@@ -121,12 +129,6 @@ class Session(object):
         self.tracker_client = _SudsClientWrapper(
             self._url_for_name("Tracker"), self, timeout
         )
-
-        # This block forces ssl certificate verification
-        if self._server.cert_path:
-            global CERT_PATH
-            CERT_PATH = self._server.cert_path
-            ssl._create_default_https_context = create_ssl_context
 
     def _login(self):
         """login to the Polarion API"""

--- a/src/pylero/session.py
+++ b/src/pylero/session.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import re
@@ -11,12 +8,14 @@ import time
 
 import suds.client
 import suds.sax.element
-from pylero._compatible import builtins  # noqa
-from pylero._compatible import object
-from pylero._compatible import urlparse
 from suds.plugin import MessagePlugin
 from suds.sax.attribute import Attribute
 
+from pylero._compatible import (
+    builtins,  # noqa
+    object,
+    urlparse,
+)
 
 logger = logging.getLogger(__name__)
 # We create a logger in order to intercept log records from suds.client
@@ -25,9 +24,7 @@ suds_logger = logging.getLogger("suds.client")
 CERT_PATH = None
 
 # Regular expression to catch SOAP message containing password field
-REGEX_SOAP_MESSAGE_PASSWORD_FIELD = re.compile(
-    r"(<ns\d:password>)(.*)(</ns\d:password>).*"
-)
+REGEX_SOAP_MESSAGE_PASSWORD_FIELD = re.compile(r"(<ns\d:password>)(.*)(</ns\d:password>).*")
 
 
 class ListenFilter(logging.Filter):
@@ -38,9 +35,7 @@ class ListenFilter(logging.Filter):
         # We assume that this message contains the password in plaintext
         # which as part of SOAP message
         if "<ns" and ":password" in record.getMessage():
-            masked_record = re.sub(
-                REGEX_SOAP_MESSAGE_PASSWORD_FIELD, r"\1*********\3", record.getMessage()
-            )
+            masked_record = re.sub(REGEX_SOAP_MESSAGE_PASSWORD_FIELD, r"\1*********\3", record.getMessage())
             logger.critical(masked_record)
             return False
         return True
@@ -84,9 +79,7 @@ class SoapNull(MessagePlugin):
 class Session(object):
     def _url_for_name(self, service_name):
         """generate the full URL for the WSDL client services"""
-        return "{0}/ws/services/{1}WebService?wsdl".format(
-            self._server.url, service_name
-        )
+        return "{0}/ws/services/{1}WebService?wsdl".format(self._server.url, service_name)
 
     def __init__(self, server, timeout):
         """Session constructor, initialize the WSDL clients
@@ -108,27 +101,13 @@ class Session(object):
             CERT_PATH = self._server.cert_path
             ssl._create_default_https_context = create_ssl_context
 
-        self._session_client = _SudsClientWrapper(
-            self._url_for_name("Session"), None, timeout
-        )
-        self.builder_client = _SudsClientWrapper(
-            self._url_for_name("Builder"), self, timeout
-        )
-        self.planning_client = _SudsClientWrapper(
-            self._url_for_name("Planning"), self, timeout
-        )
-        self.project_client = _SudsClientWrapper(
-            self._url_for_name("Project"), self, timeout
-        )
-        self.security_client = _SudsClientWrapper(
-            self._url_for_name("Security"), self, timeout
-        )
-        self.test_management_client = _SudsClientWrapper(
-            self._url_for_name("TestManagement"), self, timeout
-        )
-        self.tracker_client = _SudsClientWrapper(
-            self._url_for_name("Tracker"), self, timeout
-        )
+        self._session_client = _SudsClientWrapper(self._url_for_name("Session"), None, timeout)
+        self.builder_client = _SudsClientWrapper(self._url_for_name("Builder"), self, timeout)
+        self.planning_client = _SudsClientWrapper(self._url_for_name("Planning"), self, timeout)
+        self.project_client = _SudsClientWrapper(self._url_for_name("Project"), self, timeout)
+        self.security_client = _SudsClientWrapper(self._url_for_name("Security"), self, timeout)
+        self.test_management_client = _SudsClientWrapper(self._url_for_name("TestManagement"), self, timeout)
+        self.tracker_client = _SudsClientWrapper(self._url_for_name("Tracker"), self, timeout)
 
     def _login(self):
         """login to the Polarion API"""
@@ -140,9 +119,7 @@ class Session(object):
         id_element = sc.last_received().childAtPath("Envelope/Header/sessionID")
         session_id = id_element.text
         session_ns = id_element.namespace()
-        self._session_id_header = suds.sax.element.Element(
-            "sessionID", ns=session_ns
-        ).setText(session_id)
+        self._session_id_header = suds.sax.element.Element("sessionID", ns=session_ns).setText(session_id)
         self._cookies = sc.options.transport.cookiejar
         sc.set_options(soapheaders=self._session_id_header)
         self._last_request_at = time.time()
@@ -210,27 +187,17 @@ class _SudsClientWrapper(object):
         # every time a client function is called, this verifies that there is
         # still an active connection and if not, it reconnects.
         logger.debug("attr={0} self={1}".format(attr, self.__dict__))
-        if (
-            attr == "service"
-            and self._enclosing_session
-            and self._enclosing_session._session_id_header is not None
-        ):
+        if attr == "service" and self._enclosing_session and self._enclosing_session._session_id_header is not None:
             logger.debug("Calling hook before _suds_client_wrapper.service " "access")
             self._enclosing_session._reauth()
-            self._suds_client.set_options(
-                soapheaders=self._enclosing_session._session_id_header
-            )
+            self._suds_client.set_options(soapheaders=self._enclosing_session._session_id_header)
             # for some reason adding the cookiejar didn't work, so the
             # cookie is being added to the header manually.
             # self._suds_client.options.transport.cookiejar = \
             #    self._enclosing_session._cookies
             # adding the RouteID cookie, if it exists to the headers.
             hostname = urlparse(self._enclosing_session._server.url).hostname
-            route = (
-                self._enclosing_session._cookies._cookies.get(hostname, {})
-                .get("/", {})
-                .get("ROUTEID")
-            )
+            route = self._enclosing_session._cookies._cookies.get(hostname, {}).get("/", {}).get("ROUTEID")
             if route:
                 self._suds_client.options.headers["Cookie"] = "ROUTEID=%s" % route.value
         return getattr(self._suds_client, attr)

--- a/src/pylero/signature.py
+++ b/src/pylero/signature.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/signature_context.py
+++ b/src/pylero/signature_context.py
@@ -1,12 +1,8 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.signature import ArrayOfSignature
-from pylero.signature import Signature
+from pylero.signature import ArrayOfSignature, Signature
 from pylero.user import User
 
 

--- a/src/pylero/signature_data.py
+++ b/src/pylero/signature_data.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/subterra_uri.py
+++ b/src/pylero/subterra_uri.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/test_record.py
+++ b/src/pylero/test_record.py
@@ -1,15 +1,10 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId
-from pylero.test_run_attachment import ArrayOfTestRunAttachment
-from pylero.test_run_attachment import TestRunAttachment
-from pylero.test_step_result import ArrayOfTestStepResult
-from pylero.test_step_result import TestStepResult
+from pylero.test_run_attachment import ArrayOfTestRunAttachment, TestRunAttachment
+from pylero.test_step_result import ArrayOfTestStepResult, TestStepResult
 from pylero.text import Text
 from pylero.user import User
 from pylero.work_item import _WorkItem
@@ -80,12 +75,8 @@ class TestRecord(BasePolarion):
     def _fix_circular_refs(self):
         # need to pass in the project_id parm to the Work Item,
         # but it is not given before instatiation
-        self._cls_suds_map["test_case_id"]["additional_parms"] = {
-            "project_id": self.project_id
-        }
-        self._cls_suds_map["defect_case_id"]["additional_parms"] = {
-            "project_id": self.project_id
-        }
+        self._cls_suds_map["test_case_id"]["additional_parms"] = {"project_id": self.project_id}
+        self._cls_suds_map["defect_case_id"]["additional_parms"] = {"project_id": self.project_id}
 
 
 class ArrayOfTestRecord(BasePolarion):

--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -1,38 +1,27 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import importlib
 import os
 
 import suds
-from pylero._compatible import basestring
-from pylero._compatible import classmethod
-from pylero._compatible import object  # noqa
-from pylero._compatible import range
-from pylero.base_polarion import BasePolarion
-from pylero.base_polarion import tx_wrapper
+
+from pylero._compatible import basestring, classmethod, range
+from pylero.base_polarion import BasePolarion, tx_wrapper
 from pylero.build import Build  # noqa: F401
-from pylero.custom import ArrayOfCustom
-from pylero.custom import Custom
+from pylero.custom import ArrayOfCustom, Custom
 from pylero.custom_field_type import CustomFieldType
 from pylero.document import Document
 from pylero.enum_custom_field_type import EnumCustomFieldType
-from pylero.enum_option_id import ArrayOfEnumOptionId
-from pylero.enum_option_id import EnumOptionId
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId
 from pylero.exceptions import PyleroLibException
 from pylero.plan import Plan  # NOQA
 from pylero.project import Project
-from pylero.test_record import ArrayOfTestRecord
-from pylero.test_record import TestRecord
-from pylero.test_run_attachment import ArrayOfTestRunAttachment
-from pylero.test_run_attachment import TestRunAttachment
+from pylero.test_record import ArrayOfTestRecord, TestRecord
+from pylero.test_run_attachment import ArrayOfTestRunAttachment, TestRunAttachment
 from pylero.text import Text
 from pylero.user import User
 from pylero.work_item import _WorkItem
-
 
 # Build is used in custom fields.
 # Plan is used in custom fields.
@@ -177,9 +166,7 @@ class TestRun(BasePolarion):
         elif "Query" in self.select_test_cases_by:
             cases = _WorkItem.query(self.query + " AND project.id:" + self.project_id)
         else:
-            raise PyleroLibException(
-                "Only Test Runs based on Docs or" " Queries can be dynamic"
-            )
+            raise PyleroLibException("Only Test Runs based on Docs or" " Queries can be dynamic")
         executed_ids = [rec.test_case_id for rec in self._records]
         test_recs = self._records
         for case in cases:
@@ -229,9 +216,7 @@ class TestRun(BasePolarion):
                 project_id, test_run_id or title, title, template
             )
         else:
-            uri = cls.session.test_management_client.service.createTestRun(
-                project_id, test_run_id, template
-            )
+            uri = cls.session.test_management_client.service.createTestRun(project_id, test_run_id, template)
         if uri:
             run = cls(uri=uri)
             run.verify_params(**kwargs)
@@ -373,9 +358,7 @@ class TestRun(BasePolarion):
             function_name += "Limited"
             parms.append(limit)
         test_runs = []
-        results = getattr(cls.session.test_management_client.service, function_name)(
-            *parms
-        )
+        results = getattr(cls.session.test_management_client.service, function_name)(*parms)
         for suds_obj in results:
             tr = TestRun(suds_object=suds_obj)
             test_runs.append(tr)
@@ -406,23 +389,13 @@ class TestRun(BasePolarion):
         super(self.__class__, self).__init__(test_run_id, suds_object)
         if test_run_id:
             if not project_id:
-                raise PyleroLibException(
-                    "When test_run_id is passed in, " "project_id is required"
-                )
-            self._suds_object = (
-                self.session.test_management_client.service.getTestRunById(
-                    project_id, test_run_id
-                )
-            )
+                raise PyleroLibException("When test_run_id is passed in, " "project_id is required")
+            self._suds_object = self.session.test_management_client.service.getTestRunById(project_id, test_run_id)
         elif uri:
-            self._suds_object = (
-                self.session.test_management_client.service.getTestRunByUri(uri)
-            )
+            self._suds_object = self.session.test_management_client.service.getTestRunByUri(uri)
         if test_run_id or uri:
             if getattr(self._suds_object, "_unresolvable", True):
-                raise PyleroLibException(
-                    "The Test Run {0} was not found.".format(test_run_id)
-                )
+                raise PyleroLibException("The Test Run {0} was not found.".format(test_run_id))
 
     def _fix_circular_refs(self):
         # a class can't reference itself as a class attribute so it is
@@ -453,9 +426,7 @@ class TestRun(BasePolarion):
         field_type = field_type.split("[")[0]
         if field_type.startswith("@"):
             # an enum based on an object
-            return [
-                globals()[x] for x in globals() if x.lower() == field_type[1:].lower()
-            ][0]
+            return [globals()[x] for x in globals() if x.lower() == field_type[1:].lower()][0]
         else:
             # a regular enum
             return field_type
@@ -477,9 +448,7 @@ class TestRun(BasePolarion):
             testmanagement.getDefinedTestRunCustomFieldTypes
         """
         if not cls._custom_field_cache[project_id]:
-            cfts = cls.session.test_management_client.service.getDefinedTestRunCustomFieldTypes(
-                project_id
-            )
+            cfts = cls.session.test_management_client.service.getDefinedTestRunCustomFieldTypes(project_id)
         else:
             cfts = cls._custom_field_cache[project_id]
         results = [
@@ -511,12 +480,8 @@ class TestRun(BasePolarion):
                 f_type = self._custom_field_types(f)
             self._custom_field_cache[project_id][key] = {}
             self._custom_field_cache[project_id][key]["type"] = f_type
-            self._custom_field_cache[project_id][key]["required"] = getattr(
-                result, "required", False
-            )
-            self._custom_field_cache[project_id][key]["multi"] = getattr(
-                result, "multi", False
-            )
+            self._custom_field_cache[project_id][key]["required"] = getattr(result, "required", False)
+            self._custom_field_cache[project_id][key]["multi"] = getattr(result, "multi", False)
 
     def _add_custom_fields(self, project_id):
         """This generates object attributes, with validation, so that custom
@@ -563,9 +528,7 @@ class TestRun(BasePolarion):
                         : cache[field]["type"].__init__.__code__.co_argcount
                     ]
                 ):
-                    self._cls_suds_map[field]["additional_parms"] = {
-                        "project_id": project_id
-                    }
+                    self._cls_suds_map[field]["additional_parms"] = {"project_id": project_id}
 
     def _get_index_of_test_record(self, test_case_id):
         # specific functions request the index of the test record within the
@@ -581,10 +544,7 @@ class TestRun(BasePolarion):
                 index += 1
             if test_case_id in test_record._suds_object.testCaseURI:
                 return index
-        raise PyleroLibException(
-            "The Test Case is either not part of "
-            "this TestRun or has not been executed"
-        )
+        raise PyleroLibException("The Test Case is either not part of " "this TestRun or has not been executed")
 
     def _status_change(self):
         """Change status if necessary and possible."""
@@ -616,17 +576,13 @@ class TestRun(BasePolarion):
         # verifies the number of records is not less then the index given.
         self._verify_obj()
         if record_index > (len(self.records) - 1):
-            raise PyleroLibException(
-                "There are only {0} test records".format(len(self.records))
-            )
+            raise PyleroLibException("There are only {0} test records".format(len(self.records)))
 
     def _verify_test_step_count(self, record_index, test_step_index):
         # verifies the number of test steps is not less then the index given.
         self._verify_record_count(record_index)
         if test_step_index > (len(self.records[record_index].test_step_results) - 1):
-            raise PyleroLibException(
-                "There are only {0} test records".format(len(self.records))
-            )
+            raise PyleroLibException("There are only {0} test records".format(len(self.records)))
 
     def add_attachment_to_test_record(self, test_case_id, path, title):
         """method add_attachment_to_test_record, adds the given attachment to
@@ -675,9 +631,7 @@ class TestRun(BasePolarion):
         self._verify_obj()
         data = self._get_file_data(path)
         filename = os.path.basename(path)
-        self.session.test_management_client.service.addAttachmentToTestRun(
-            self.uri, filename, title, data
-        )
+        self.session.test_management_client.service.addAttachmentToTestRun(self.uri, filename, title, data)
 
     def add_attachment_to_test_step(self, test_case_id, test_step_index, path, title):
         """method add_attachment_to_test_step, adds the given attachment to
@@ -727,13 +681,10 @@ class TestRun(BasePolarion):
             None
         """
         check_tr = TestRun.search(
-            'project.id:%s AND id:"%s" AND %s'
-            % (self.project_id, self.test_run_id, test_case_id)
+            'project.id:%s AND id:"%s" AND %s' % (self.project_id, self.test_run_id, test_case_id)
         )
         if len(check_tr) not in [0, 1]:
-            raise PyleroLibException(
-                "The search function did not work as expected. Please report."
-            )
+            raise PyleroLibException("The search function did not work as expected. Please report.")
         elif len(check_tr) == 1:
             raise PyleroLibException("This test case is already part of the test run")
         else:
@@ -790,9 +741,7 @@ class TestRun(BasePolarion):
             testrec.defect_case_id = defect_work_item_id
         self.add_test_record_by_object(testrec, create_incident=create_incident)
 
-    def __generate_description(
-        self, test_case: _WorkItem, test_record: TestRecord
-    ) -> str:
+    def __generate_description(self, test_case: _WorkItem, test_record: TestRecord) -> str:
         """Generates the description for the incident report.
 
         If the test case has test steps that match the steps of the test record,
@@ -819,10 +768,7 @@ class TestRun(BasePolarion):
             'data-item-id="{0}" data-option-id="long"></span>'
             "<br/>".format(test_case.work_item_id)
         )
-        table_cell_style = (
-            'style="text-align: left; padding: 10px; '
-            'vertical-align: top; background-color: #ffffff;"'
-        )
+        table_cell_style = 'style="text-align: left; padding: 10px; ' 'vertical-align: top; background-color: #ffffff;"'
         table_row_style = 'style="border-bottom: 1px solid #f0f0f0;"'
         columns = [
             "",
@@ -860,12 +806,7 @@ class TestRun(BasePolarion):
             '-collapse: collapse;"><tr style="text-align: left; '
             "white-space: nowrap; color: #757575; border-bottom: 1px "
             'solid #d2d7da; background-color: #ffffff;">{0}</tr>'.format(
-                "".join(
-                    [
-                        "<th {0}>{1}</th>".format(table_cell_style, column)
-                        for column in columns
-                    ]
-                )
+                "".join(["<th {0}>{1}</th>".format(table_cell_style, column) for column in columns])
             )
         )
         verdict = (
@@ -896,9 +837,7 @@ class TestRun(BasePolarion):
                     "</tr>".format(
                         table_row_style,
                         table_cell_style,
-                        test_step_results.get(
-                            test_record.test_step_results[step].result
-                        ),
+                        test_step_results.get(test_record.test_step_results[step].result),
                         step + 1,
                         test_steps.steps[step].values[0].content,
                         test_steps.steps[step].values[1].content,
@@ -917,9 +856,7 @@ class TestRun(BasePolarion):
         content = tr_html + tc_html + table + verdict
         return content
 
-    def __create_incident_report(
-        self, test_case_id: str, test_record: TestRecord
-    ) -> str:
+    def __create_incident_report(self, test_case_id: str, test_record: TestRecord) -> str:
         """Create and populate an incident work item.
 
         The work_item type of the incident and the fields to copy from the test
@@ -949,9 +886,7 @@ class TestRun(BasePolarion):
             wi_class_names = getattr(work_item_module, "workitems")
             test_case_class_name = wi_class_names[test_case_wi_type]
             test_case_class = getattr(work_item_module, test_case_class_name)
-            test_case = test_case_class(
-                project_id=self.project_id, work_item_id=test_case_id
-            )
+            test_case = test_case_class(project_id=self.project_id, work_item_id=test_case_id)
         except (AttributeError, PyleroLibException):
             test_case = _WorkItem(project_id=self.project_id, work_item_id=test_case_id)
 
@@ -966,16 +901,11 @@ class TestRun(BasePolarion):
                 kwarg_dict[prop.value] = getattr(self, prop.key)
 
         try:
-            incident_report = _WorkItem.create(
-                project_id, defect_wi_type, title, description, status, **kwarg_dict
-            )
+            incident_report = _WorkItem.create(project_id, defect_wi_type, title, description, status, **kwarg_dict)
         except PyleroLibException as e:
             msg = "\n".join(
                 [
-                    (
-                        f"Failed to create the work item {title} in"
-                        f"project {project_id} of type {defect_wi_type}."
-                    ),
+                    (f"Failed to create the work item {title} in" f"project {project_id} of type {defect_wi_type}."),
                     f"Error: {e}",
                 ]
             )
@@ -984,9 +914,7 @@ class TestRun(BasePolarion):
         return incident_report.work_item_id
 
     @tx_wrapper
-    def add_test_record_by_object(
-        self, test_record, manual_state_change=False, create_incident=True
-    ):
+    def add_test_record_by_object(self, test_record, manual_state_change=False, create_incident=True):
         """method add_test_record_by_object, adds a test record for the given
         test case based on the TestRecord object passed in.
         In addition, the test run is checked for completeness and the test
@@ -1014,18 +942,12 @@ class TestRun(BasePolarion):
             suds_object = test_record._suds_object
         elif isinstance(test_record, TestRecord()._suds_object.__class__):
             suds_object = test_record
-        if (
-            test_record.result == "failed"
-            and not test_record.defect_case_id
-            and create_incident
-        ):
+        if test_record.result == "failed" and not test_record.defect_case_id and create_incident:
             test_record.defect_case_id = self.__create_incident_report(
                 test_case_id,
                 test_record,
             )
-        self.session.test_management_client.service.addTestRecordToTestRun(
-            self.uri, suds_object
-        )
+        self.session.test_management_client.service.addTestRecordToTestRun(self.uri, suds_object)
 
         if manual_state_change:
             self.update()
@@ -1051,13 +973,9 @@ class TestRun(BasePolarion):
         self._verify_obj()
         defect_template_uri = None
         if defect_template_id:
-            suds_defect_template = _WorkItem(
-                work_item_id=defect_template_id, project_id=self.project_id
-            )
+            suds_defect_template = _WorkItem(work_item_id=defect_template_id, project_id=self.project_id)
             defect_template_uri = suds_defect_template._uri
-        wi_uri = self.session.test_management_client.service.createSummaryDefect(
-            self.uri, defect_template_uri
-        )
+        wi_uri = self.session.test_management_client.service.createSummaryDefect(self.uri, defect_template_uri)
         return _WorkItem(uri=wi_uri)
 
     def delete_attachment_from_test_record(self, test_case_id, filename):
@@ -1076,9 +994,7 @@ class TestRun(BasePolarion):
         """
         record_index = self._get_index_of_test_record(test_case_id)
         self._verify_record_count(record_index)
-        self.session.test_management_client.service.deleteAttachmentFromTestRecord(
-            self.uri, record_index, filename
-        )
+        self.session.test_management_client.service.deleteAttachmentFromTestRecord(self.uri, record_index, filename)
 
     def delete_attachment_from_test_step(self, test_case_id, test_step_index, filename):
         """Deletes Test Step Attachment of the specified step in the specified
@@ -1114,9 +1030,7 @@ class TestRun(BasePolarion):
             test_management.deleteTestRunAttachment
         """
         self._verify_obj()
-        self.session.test_management_client.service.deleteTestRunAttachment(
-            self.uri, filename
-        )
+        self.session.test_management_client.service.deleteTestRunAttachment(self.uri, filename)
 
     def get_attachment(self, filename):
         """Gets Test Run Attachment specified by attachment's
@@ -1132,9 +1046,7 @@ class TestRun(BasePolarion):
             test_management.getTestRunAttachment
         """
         self._verify_obj()
-        suds_attach = self.session.test_management_client.service.getTestRunAttachment(
-            self.uri, filename
-        )
+        suds_attach = self.session.test_management_client.service.getTestRunAttachment(self.uri, filename)
         return TestRunAttachment(suds_object=suds_attach)
 
     def get_attachments(self):
@@ -1150,13 +1062,8 @@ class TestRun(BasePolarion):
             test_management.getTestRunAttachments
         """
         self._verify_obj()
-        lst_suds_attach = (
-            self.session.test_management_client.service.getTestRunAttachments(self.uri)
-        )
-        lst_attach = [
-            TestRunAttachment(suds_object=suds_attach)
-            for suds_attach in lst_suds_attach
-        ]
+        lst_suds_attach = self.session.test_management_client.service.getTestRunAttachments(self.uri)
+        lst_attach = [TestRunAttachment(suds_object=suds_attach) for suds_attach in lst_suds_attach]
         return lst_attach
 
     def get_custom_field(self, field_name):
@@ -1193,11 +1100,7 @@ class TestRun(BasePolarion):
             test_management.getWikiContentForTestRun
         """
         self._verify_obj()
-        suds_wiki = (
-            self.session.test_management_client.service.getWikiContentForTestRun(
-                self.uri
-            )
-        )
+        suds_wiki = self.session.test_management_client.service.getWikiContentForTestRun(self.uri)
         return Text(suds_object=suds_wiki)
 
     def _set_custom_field(self, field_name, value):
@@ -1271,13 +1174,9 @@ class TestRun(BasePolarion):
         self._verify_obj()
         data = self._get_file_data(path)
         filename = os.path.basename(original_filename)
-        self.session.test_management_client.service.updateTestRunAttachment(
-            self.uri, filename, title, data
-        )
+        self.session.test_management_client.service.updateTestRunAttachment(self.uri, filename, title, data)
 
-    def update_summary_defect(
-        self, source, total_failures, total_errors, total_tests, defect_template_id
-    ):
+    def update_summary_defect(self, source, total_failures, total_errors, total_tests, defect_template_id):
         """method update-summary_defect creates or updates the summary defect
         Work Item of a test run.
 
@@ -1301,9 +1200,7 @@ class TestRun(BasePolarion):
             test_management.updateSummaryDefect
         """
         self._verify_obj()
-        suds_defect_template = _WorkItem(
-            work_item_id=defect_template_id, project_id=self.project_id
-        )
+        suds_defect_template = _WorkItem(work_item_id=defect_template_id, project_id=self.project_id)
         defect_template_uri = suds_defect_template._uri
         wi_uri = self.session.test_management_client.service.updateSummaryDefect(
             self.uri,
@@ -1363,9 +1260,7 @@ class TestRun(BasePolarion):
         testrec.duration = duration
         if defect_work_item_id:
             testrec.defect_case_id = defect_work_item_id
-        self.update_test_record_by_object(
-            test_case_id, testrec, create_incident=create_incident
-        )
+        self.update_test_record_by_object(test_case_id, testrec, create_incident=create_incident)
 
     @tx_wrapper
     def update_test_record_by_object(
@@ -1406,22 +1301,14 @@ class TestRun(BasePolarion):
         if test_case_id not in test_case_ids:
             self.add_test_record_by_object(test_record, create_incident=create_incident)
         else:
-            if (
-                test_record.result == "failed"
-                and not test_record.defect_case_id
-                and create_incident
-            ):
-                test_record.defect_case_id = self.__create_incident_report(
-                    test_case_id, test_record
-                )
+            if test_record.result == "failed" and not test_record.defect_case_id and create_incident:
+                test_record.defect_case_id = self.__create_incident_report(test_case_id, test_record)
             index = test_case_ids.index(test_case_id)
             if isinstance(test_record, TestRecord):
                 suds_object = test_record._suds_object
             elif isinstance(test_record, TestRecord()._suds_object.__class__):
                 suds_object = test_record
-            self.session.test_management_client.service.updateTestRecordAtIndex(
-                self.uri, index, suds_object
-            )
+            self.session.test_management_client.service.updateTestRecordAtIndex(self.uri, index, suds_object)
             if manual_state_change:
                 self.update()
             else:
@@ -1450,9 +1337,7 @@ class TestRun(BasePolarion):
                 suds_content = content
         else:
             suds_content = suds.null()
-        self.session.test_management_client.service.updateWikiContentForTestRun(
-            self.uri, suds_content
-        )
+        self.session.test_management_client.service.updateWikiContentForTestRun(self.uri, suds_content)
 
     def verify_required(self):
         """function that checks if all required fields are passed in
@@ -1465,9 +1350,7 @@ class TestRun(BasePolarion):
             if not getattr(self, req):
                 fields += (", " if fields else "") + req
         if fields:
-            raise PyleroLibException(
-                "These parameters are required: {0}".format(fields)
-            )
+            raise PyleroLibException("These parameters are required: {0}".format(fields))
 
     def verify_params(self, **kwargs):
         """function that checks if all the kwargs are valid attributes.

--- a/src/pylero/test_run_attachment.py
+++ b/src/pylero/test_run_attachment.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.user import User

--- a/src/pylero/test_step.py
+++ b/src/pylero/test_step.py
@@ -1,12 +1,8 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.text import ArrayOfText
-from pylero.text import Text
+from pylero.text import ArrayOfText, Text
 
 
 class TestStep(BasePolarion):

--- a/src/pylero/test_step_result.py
+++ b/src/pylero/test_step_result.py
@@ -1,13 +1,9 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId
-from pylero.test_run_attachment import ArrayOfTestRunAttachment
-from pylero.test_run_attachment import TestRunAttachment
+from pylero.test_run_attachment import ArrayOfTestRunAttachment, TestRunAttachment
 from pylero.text import Text
 
 

--- a/src/pylero/test_steps.py
+++ b/src/pylero/test_steps.py
@@ -1,14 +1,9 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
-from pylero.enum_option_id import ArrayOfEnumOptionId
-from pylero.enum_option_id import EnumOptionId
-from pylero.test_step import ArrayOfTestStep
-from pylero.test_step import TestStep
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId
+from pylero.test_step import ArrayOfTestStep, TestStep
 
 
 class TestSteps(BasePolarion):

--- a/src/pylero/tests_configuration.py
+++ b/src/pylero/tests_configuration.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.properties import Properties

--- a/src/pylero/text.py
+++ b/src/pylero/text.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 

--- a/src/pylero/time_point.py
+++ b/src/pylero/time_point.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.text import Text

--- a/src/pylero/user.py
+++ b/src/pylero/user.py
@@ -1,13 +1,9 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.exceptions import PyleroLibException
-from pylero.subterra_uri import ArrayOfSubterraURI
-from pylero.subterra_uri import SubterraURI
+from pylero.subterra_uri import ArrayOfSubterraURI, SubterraURI
 from pylero.text import Text
 
 
@@ -126,9 +122,7 @@ class User(BasePolarion):
             if user_id:
                 self._suds_object = self.session.project_client.service.getUser(user_id)
             elif uri:
-                self._suds_object = self.session.project_client.service.getUserByUri(
-                    uri
-                )
+                self._suds_object = self.session.project_client.service.getUserByUri(uri)
             if getattr(self._suds_object, "_unresolvable", True):
                 raise PyleroLibException("The user {0} was not found.".format(user_id))
 
@@ -145,9 +139,7 @@ class User(BasePolarion):
             Security.getContextRolesForUser
         """
         self._verify_obj()
-        return self.session.security_client.service.getContextRolesForUser(
-            self.user_id, location
-        )
+        return self.session.security_client.service.getContextRolesForUser(self.user_id, location)
 
     def get_roles(self, location):
         """Returns all global and context roles for the context at given
@@ -163,9 +155,7 @@ class User(BasePolarion):
             Security.getRolesForUser
         """
         self._verify_obj()
-        return self.session.security_client.service.getRolesForUser(
-            self.user_id, location
-        )
+        return self.session.security_client.service.getRolesForUser(self.user_id, location)
 
     # getUserAvatarURL parameter is misnamed in the docs. it really takes user id.
     def get_user_avatar_url(self):
@@ -201,9 +191,7 @@ class User(BasePolarion):
             Security.hasPermission
         """
         self._verify_obj()
-        return self.session.security_client.service.hasPermission(
-            self.user_id, permission, project_id
-        )
+        return self.session.security_client.service.hasPermission(self.user_id, permission, project_id)
 
     def update(self):
         """method update, updates Polarion with the User attributes

--- a/src/pylero/wiki_page.py
+++ b/src/pylero/wiki_page.py
@@ -1,17 +1,12 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.project import Project
-from pylero.subterra_uri import ArrayOfSubterraURI
-from pylero.subterra_uri import SubterraURI
+from pylero.subterra_uri import ArrayOfSubterraURI, SubterraURI
 from pylero.text import Text
 from pylero.user import User
-from pylero.wiki_page_attachment import ArrayOfWikiPageAttachment
-from pylero.wiki_page_attachment import WikiPageAttachment
+from pylero.wiki_page_attachment import ArrayOfWikiPageAttachment, WikiPageAttachment
 
 
 class WikiPage(BasePolarion):
@@ -85,9 +80,7 @@ class WikiPage(BasePolarion):
             function_name += "WithFields"
             parms += [cls._convert_obj_fields_to_polarion(fields)]
         wikis = []
-        for suds_wiki in getattr(cls.session.tracker_client.service, function_name)(
-            *parms
-        ):
+        for suds_wiki in getattr(cls.session.tracker_client.service, function_name)(*parms):
             wikis.append(cls(suds_object=suds_wiki))
         return wikis
 
@@ -183,6 +176,4 @@ class WikiPage(BasePolarion):
             if fields:
                 function_name += "WithFields"
                 parms += [self._convert_obj_fields_to_polarion(fields)]
-            self._suds_object = getattr(
-                self.session.tracker_client.service, function_name
-            )(*parms)
+            self._suds_object = getattr(self.session.tracker_client.service, function_name)(*parms)

--- a/src/pylero/wiki_page_attachment.py
+++ b/src/pylero/wiki_page_attachment.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.user import User

--- a/src/pylero/work_item.py
+++ b/src/pylero/work_item.py
@@ -1,55 +1,38 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 import os
 import re
 
 import suds
+
 from pylero._compatible import basestring
-from pylero.approval import Approval
-from pylero.approval import ArrayOfApproval
-from pylero.attachment import ArrayOfAttachment
-from pylero.attachment import Attachment
-from pylero.base_polarion import BasePolarion
-from pylero.base_polarion import Configuration
-from pylero.base_polarion import tx_wrapper
-from pylero.category import ArrayOfCategory
-from pylero.category import Category
-from pylero.comment import ArrayOfComment
-from pylero.comment import Comment
-from pylero.custom import ArrayOfCustom
-from pylero.custom import Custom
+from pylero.approval import Approval, ArrayOfApproval
+from pylero.attachment import ArrayOfAttachment, Attachment
+from pylero.base_polarion import BasePolarion, Configuration, tx_wrapper
+from pylero.category import ArrayOfCategory, Category
+from pylero.comment import ArrayOfComment, Comment
+from pylero.custom import ArrayOfCustom, Custom
 from pylero.custom_field import CustomField
 from pylero.custom_field_type import CustomFieldType
 from pylero.enum_custom_field_type import EnumCustomFieldType
-from pylero.enum_option_id import ArrayOfEnumOptionId  # NOQA
 from pylero.enum_option_id import EnumOptionId
 from pylero.exceptions import PyleroLibException
-from pylero.externally_linked_work_item import ArrayOfExternallyLinkedWorkItem
-from pylero.externally_linked_work_item import ExternallyLinkedWorkItem
-from pylero.hyperlink import ArrayOfHyperlink
-from pylero.hyperlink import Hyperlink
-from pylero.linked_work_item import ArrayOfLinkedWorkItem
-from pylero.linked_work_item import LinkedWorkItem
-from pylero.planning_constraint import ArrayOfPlanningConstraint
-from pylero.planning_constraint import PlanningConstraint
+from pylero.externally_linked_work_item import ArrayOfExternallyLinkedWorkItem, ExternallyLinkedWorkItem
+from pylero.hyperlink import ArrayOfHyperlink, Hyperlink
+from pylero.linked_work_item import ArrayOfLinkedWorkItem, LinkedWorkItem
+from pylero.planning_constraint import ArrayOfPlanningConstraint, PlanningConstraint
 from pylero.priority_option_id import PriorityOptionId
 from pylero.project import Project
-from pylero.revision import ArrayOfRevision
-from pylero.revision import Revision
+from pylero.revision import ArrayOfRevision, Revision
 from pylero.subterra_uri import SubterraURI
 from pylero.test_step import TestStep
 from pylero.test_steps import TestSteps
 from pylero.text import Text
 from pylero.time_point import TimePoint
-from pylero.user import ArrayOfUser
-from pylero.user import User
-from pylero.work_record import ArrayOfWorkRecord
-from pylero.work_record import WorkRecord
+from pylero.user import ArrayOfUser, User
+from pylero.work_record import ArrayOfWorkRecord, WorkRecord
 from pylero.workflow_action import WorkflowAction
 
 # ArrayOfEnumOptionId is used in dynamic code for custom fields
@@ -327,9 +310,7 @@ class _WorkItem(BasePolarion):
             tracker.getDefinedCustomFieldTypes
         """
         if not cls._cache["custom_field_types"].get(wi_type):
-            cfts = cls.session.tracker_client.service.getDefinedCustomFieldTypes(
-                project_id, wi_type
-            )
+            cfts = cls.session.tracker_client.service.getDefinedCustomFieldTypes(project_id, wi_type)
             cls._cache["custom_field_types"][wi_type] = cfts
         else:
             cfts = cls._cache["custom_field_types"].get(wi_type)
@@ -501,24 +482,12 @@ class _WorkItem(BasePolarion):
                 function_name += "Id" if not p_fields else "IdsWithFields"
                 parms = [project_id, work_item_id] + ([p_fields] if p_fields else [])
             elif uri:
-                function_name += (
-                    "Uri"
-                    + ("InRevision" if revision else "")
-                    + ("WithFields" if p_fields else "")
-                )
-                parms = (
-                    [uri]
-                    + ([revision] if revision else [])
-                    + ([p_fields] if p_fields else [])
-                )
-            self._suds_object = getattr(
-                self.session.tracker_client.service, function_name
-            )(*parms)
+                function_name += "Uri" + ("InRevision" if revision else "") + ("WithFields" if p_fields else "")
+                parms = [uri] + ([revision] if revision else []) + ([p_fields] if p_fields else [])
+            self._suds_object = getattr(self.session.tracker_client.service, function_name)(*parms)
         if not suds_object:
             if getattr(self._suds_object, "_unresolvable", True):
-                raise PyleroLibException(
-                    "The WorkItem {0} was not found.".format(work_item_id)
-                )
+                raise PyleroLibException("The WorkItem {0} was not found.".format(work_item_id))
         # if it is a suds object, only relevant fields are passed in.
         if not self.project_id and not suds_object:
             self.project_id = self.default_project
@@ -527,8 +496,7 @@ class _WorkItem(BasePolarion):
         # This module imports plan and plan imports this module.
         # The module references itself as a class attribute, which is not
         # allowed, so the self reference is defined here.
-        from pylero.plan import Plan
-        from pylero.plan import ArrayOfPlan
+        from pylero.plan import ArrayOfPlan, Plan
 
         self._cls_suds_map["planned_in"]["is_array"] = True
         self._cls_suds_map["planned_in"]["cls"] = Plan
@@ -612,9 +580,7 @@ class _WorkItem(BasePolarion):
             Tracker.addExternalLinkedRevision
         """
         self._verify_obj()
-        return self.session.tracker_client.service.addExternalLinkedRevision(
-            self.uri, repository_name, revision_id
-        )
+        return self.session.tracker_client.service.addExternalLinkedRevision(self.uri, repository_name, revision_id)
 
     def add_hyperlink(self, url, role):
         """method add_hyperlink adds a hyperlink to a _WorkItem
@@ -632,13 +598,9 @@ class _WorkItem(BasePolarion):
         self._verify_obj()
         self.check_valid_field_values(role, "hyperlink-role", {})
         suds_role = EnumOptionId(role)._suds_object
-        return self.session.tracker_client.service.addHyperlink(
-            self.uri, url, suds_role
-        )
+        return self.session.tracker_client.service.addHyperlink(self.uri, url, suds_role)
 
-    def add_linked_item(
-        self, linked_work_item_id, role, revision=None, suspect=None, project_id=None
-    ):
+    def add_linked_item(self, linked_work_item_id, role, revision=None, suspect=None, project_id=None):
         """method add_linked_item adds a linked _WorkItem to current _WorkItem
         The linking is done to the "child" object. For example, if you have a
         Test Case that verifies a requirement, you would add the
@@ -712,9 +674,7 @@ class _WorkItem(BasePolarion):
         self._verify_obj()
         data = self._get_file_data(path)
         filename = os.path.basename(path)
-        self.session.tracker_client.service.createAttachment(
-            self.uri, filename, title, data
-        )
+        self.session.tracker_client.service.createAttachment(self.uri, filename, title, data)
 
     def create_comment(self, content, title=None, parent_uri=None):
         """method create_comment adds a comment to the current _WorkItem.
@@ -754,16 +714,10 @@ class _WorkItem(BasePolarion):
             title = None
             is_existing_comment = any([str(c.uri) == parent_uri for c in self.comments])
             if not is_existing_comment:
-                raise PyleroLibException(
-                    "The parent_uri is not a valid comment for this work item"
-                )
-        self.session.tracker_client.service.addComment(
-            str(parent_uri), title, suds_content
-        )
+                raise PyleroLibException("The parent_uri is not a valid comment for this work item")
+        self.session.tracker_client.service.addComment(str(parent_uri), title, suds_content)
 
-    def create_work_record(
-        self, user_id, date_worked, time_spent, record_type=None, record_comment=None
-    ):
+    def create_work_record(self, user_id, date_worked, time_spent, record_type=None, record_comment=None):
         """Creates a work record
 
         Args:
@@ -859,9 +813,7 @@ class _WorkItem(BasePolarion):
         User(approvee_id)
         self.check_valid_field_values(status, "approval-status", {})
         suds_status = EnumOptionId(status)._suds_object
-        self.session.tracker_client.service.editApproval(
-            self.uri, approvee_id, suds_status
-        )
+        self.session.tracker_client.service.editApproval(self.uri, approvee_id, suds_status)
 
     def get_allowed_approvers(self):
         """Gets all allowed approvers"
@@ -876,9 +828,7 @@ class _WorkItem(BasePolarion):
             Tracker.getAllowedApprovers
         """
         users = []
-        for suds_user in self.session.tracker_client.service.getAllowedApprovers(
-            self.uri
-        ):
+        for suds_user in self.session.tracker_client.service.getAllowedApprovers(self.uri):
             users.append(User(suds_object=suds_user))
         return users
 
@@ -895,9 +845,7 @@ class _WorkItem(BasePolarion):
             Tracker.getAllowedAssignees
         """
         users = []
-        for suds_user in self.session.tracker_client.service.getAllowedAssignees(
-            self.uri
-        ):
+        for suds_user in self.session.tracker_client.service.getAllowedAssignees(self.uri):
             users.append(User(suds_object=suds_user))
         return users
 
@@ -917,9 +865,7 @@ class _WorkItem(BasePolarion):
         """
         self._verify_obj()
         actions = []
-        for suds_action in self.session.tracker_client.service.getAvailableActions(
-            self.uri
-        ):
+        for suds_action in self.session.tracker_client.service.getAvailableActions(self.uri):
             actions.append(WorkflowAction(suds_object=suds_action))
         return actions
 
@@ -938,9 +884,7 @@ class _WorkItem(BasePolarion):
         """
         self._verify_obj()
         linked_work_items = []
-        for suds_lwi in self.session.tracker_client.service.getBackLinkedWorkitems(
-            self.uri
-        ):
+        for suds_lwi in self.session.tracker_client.service.getBackLinkedWorkitems(self.uri):
             linked_work_items.append(LinkedWorkItem(suds_object=suds_lwi))
         return linked_work_items
 
@@ -990,9 +934,7 @@ class _WorkItem(BasePolarion):
             Tracker.getCustomFieldType
         """
         self._verify_obj()
-        suds_custom = self.session.tracker_client.service.getCustomFieldType(
-            self.uri, key
-        )
+        suds_custom = self.session.tracker_client.service.getCustomFieldType(self.uri, key)
         return CustomFieldType(suds_object=suds_custom)
 
     def get_custom_field_types(self):
@@ -1010,9 +952,7 @@ class _WorkItem(BasePolarion):
         """
         self._verify_obj()
         custom_types = []
-        for suds_custom in self.session.tracker_client.service.getCustomFieldTypes(
-            self.uri
-        ):
+        for suds_custom in self.session.tracker_client.service.getCustomFieldTypes(self.uri):
             custom_types.append(CustomFieldType(suds_object=suds_custom))
 
     def get_enum_control_key_for_id(self, enum_id):
@@ -1027,9 +967,7 @@ class _WorkItem(BasePolarion):
         References:
             Tracker.getEnumControlKeyForId
         """
-        return self.session.tracker_client.service.getEnumControlKeyForId(
-            self.project_id, enum_id
-        )
+        return self.session.tracker_client.service.getEnumControlKeyForId(self.project_id, enum_id)
 
     def get_enum_control_key_for_key(self, key):
         """Gets the enumeration control key for the specified work item key.
@@ -1044,9 +982,7 @@ class _WorkItem(BasePolarion):
         References:
             Tracker.getEnumControlKeyForId
         """
-        return self.session.tracker_client.service.getEnumControlKeyForId(
-            self.project_id, key
-        )
+        return self.session.tracker_client.service.getEnumControlKeyForId(self.project_id, key)
 
     def get_initial_workflow_action(self, work_item_type=None):
         """Gets the initial workflow action for the specified object, returns
@@ -1106,9 +1042,7 @@ class _WorkItem(BasePolarion):
         """
         self._verify_obj()
         actions = []
-        for suds_action in self.session.tracker_client.service.getUnavailableActions(
-            self.uri
-        ):
+        for suds_action in self.session.tracker_client.service.getUnavailableActions(self.uri):
             actions.append(WorkflowAction(suds_object=suds_action))
         return actions
 
@@ -1172,9 +1106,7 @@ class _WorkItem(BasePolarion):
             Tracker.removeExternalLinkedRevision
         """
         self._verify_obj()
-        return self.session.tracker_client.service.removeExternalLinkedRevision(
-            self.uri, repository_name, revision_id
-        )
+        return self.session.tracker_client.service.removeExternalLinkedRevision(self.uri, repository_name, revision_id)
 
     def remove_externally_linked_item(self, linked_external_workitem_id, role):
         """Removes an externally linked work item.
@@ -1191,9 +1123,7 @@ class _WorkItem(BasePolarion):
         """
         self._verify_obj()
         external_wi = _WorkItem(uri=linked_external_workitem_id)
-        return self.session.tracker_client.service.removeExternallyLinkedItem(
-            self.uri, external_wi.uri, role
-        )
+        return self.session.tracker_client.service.removeExternallyLinkedItem(self.uri, external_wi.uri, role)
 
     def remove_hyperlink(self, url):
         """Removes a hyperlink from the _WorkItem
@@ -1226,9 +1156,7 @@ class _WorkItem(BasePolarion):
         self._verify_obj()
         wi_linked = _WorkItem(work_item_id=linked_item_id, project_id=self.project_id)
         enum_role = EnumOptionId(role)._suds_object
-        return self.session.tracker_client.service.removeLinkedItem(
-            self.uri, wi_linked.uri, enum_role
-        )
+        return self.session.tracker_client.service.removeLinkedItem(self.uri, wi_linked.uri, enum_role)
 
     def remove_linked_revision(self, revision_id):
         """Removes a revision
@@ -1243,9 +1171,7 @@ class _WorkItem(BasePolarion):
             Tracker.removeLinkedRevision
         """
         self._verify_obj()
-        return self.session.tracker_client.service.removeLinkedRevision(
-            self.uri, revision_id
-        )
+        return self.session.tracker_client.service.removeLinkedRevision(self.uri, revision_id)
 
     def remove_planning_constraint(self, constraint_date, constraint):
         """Removes a planning constraint
@@ -1261,9 +1187,7 @@ class _WorkItem(BasePolarion):
             Tracker.removePlaningConstraint
         """
         self._verify_obj()
-        return self.session.tracker_client.service.removePlaningConstraint(
-            self.uri, constraint_date, constraint
-        )
+        return self.session.tracker_client.service.removePlaningConstraint(self.uri, constraint_date, constraint)
 
     def reset_workflow(self):
         """resets the workflow for the current object. Performs initial action
@@ -1380,9 +1304,7 @@ class _WorkItem(BasePolarion):
         self._verify_obj()
         data = self._get_file_data(path)
         filename = os.path.basename(path)
-        self.session.tracker_client.service.updateAttachment(
-            self.uri, attachment_id, filename, title, data
-        )
+        self.session.tracker_client.service.updateAttachment(self.uri, attachment_id, filename, title, data)
 
     def verify_required(self):
         for field in self._required_fields:
@@ -1438,17 +1360,13 @@ class _SpecificWorkItem(_WorkItem):
             if req not in kwargs:
                 fields += (", " if fields else "") + req
         if fields:
-            raise PyleroLibException(
-                "These parameters are required: {0}".format(fields)
-            )
+            raise PyleroLibException("These parameters are required: {0}".format(fields))
         for field in kwargs:
             if field not in cls._all_custom_fields and field not in cls._cls_suds_map:
                 fields += (", " if fields else "") + field
         if fields:
             raise PyleroLibException("These parameters are unknown: {0}".format(fields))
-        return super(_SpecificWorkItem, cls).create(
-            project_id, cls._wi_type, title, desc, status, **kwargs
-        )
+        return super(_SpecificWorkItem, cls).create(project_id, cls._wi_type, title, desc, status, **kwargs)
 
     @classmethod
     def get_custom_fields(cls, project_id):
@@ -1470,11 +1388,7 @@ class _SpecificWorkItem(_WorkItem):
             # possible
             split_name = re.findall("[a-zA-Z][^A-Z]*", cft.cft_id)
             local_name = (
-                "_".join(split_name)
-                .replace("_U_R_I", "_uri")
-                .replace("_W_I", "_wi")
-                .replace("_I_D", "_id")
-                .lower()
+                "_".join(split_name).replace("_U_R_I", "_uri").replace("_W_I", "_wi").replace("_I_D", "_id").lower()
             )
             cls._all_custom_fields.append(local_name)
             cls._cls_suds_map[local_name] = {}
@@ -1564,9 +1478,7 @@ class _SpecificWorkItem(_WorkItem):
             cls._wi_type,
             project_id or cls.default_project,
         )
-        return super(_SpecificWorkItem, cls).query(
-            query, False, fields, sort, limit, baseline_revision, query_uris
-        )
+        return super(_SpecificWorkItem, cls).query(query, False, fields, sort, limit, baseline_revision, query_uris)
 
     def __init__(
         self,
@@ -1586,15 +1498,11 @@ class _SpecificWorkItem(_WorkItem):
             project_id = self.default_project
         self._changed_fields = {}
         self.get_custom_fields(project_id)
-        super(_SpecificWorkItem, self).__init__(
-            project_id, work_item_id, suds_object, uri, fields, revision
-        )
+        super(_SpecificWorkItem, self).__init__(project_id, work_item_id, suds_object, uri, fields, revision)
         if not self.type:
             self.type = self._wi_type
         if self.type != self._wi_type:
-            raise PyleroLibException(
-                "This is of type {0}, not type {1}".format(self.type, self._wi_type)
-            )
+            raise PyleroLibException("This is of type {0}, not type {1}".format(self.type, self._wi_type))
 
     @tx_wrapper
     def update(self):

--- a/src/pylero/work_record.py
+++ b/src/pylero/work_record.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/pylero/workflow_action.py
+++ b/src/pylero/workflow_action.py
@@ -1,8 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pylero.base_polarion import BasePolarion
 from pylero.enum_option_id import EnumOptionId

--- a/src/unit_tests/attribute_test.py
+++ b/src/unit_tests/attribute_test.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 import unittest
@@ -13,8 +10,7 @@ from pylero.test_record import TestRecord
 from pylero.test_run import TestRun
 from pylero.test_steps import TestSteps
 from pylero.user import User
-from pylero.work_item import Requirement
-from pylero.work_item import TestCase
+from pylero.work_item import Requirement, TestCase
 
 USER = "user1"
 ALT_USER = "user2"
@@ -42,9 +38,7 @@ class AttributeTest(unittest.TestCase):
             ["testcase"],
             "testspecification",
         )
-        cls.testrun = TestRun.create(
-            DEFAULT_PROJ, TEST_RUN_ID, "example", TEST_RUN_TITLE
-        )
+        cls.testrun = TestRun.create(DEFAULT_PROJ, TEST_RUN_ID, "example", TEST_RUN_TITLE)
         TEST_RUN_ID = cls.testrun.test_run_id
         # arch is a custom field defined by global admins for test runs.
         # It is set here for a test on custom fields that requires at least two
@@ -162,9 +156,7 @@ class AttributeTest(unittest.TestCase):
     def test_uri_obj(self):
         testrun2 = TestRun(project_id=DEFAULT_PROJ, test_run_id=TEST_RUN_ID)
         self.assertEqual(testrun2.template, "example")
-        new_template = TestRun.create_template(
-            DEFAULT_PROJ, TEMPLATE_ID, "example", title=TEMPLATE_TITLE
-        )
+        new_template = TestRun.create_template(DEFAULT_PROJ, TEMPLATE_ID, "example", title=TEMPLATE_TITLE)
         testrun2.template = new_template
         self.assertEqual(testrun2.template, new_template.test_run_id)
         self.assertNotEqual(testrun2.template, "example")

--- a/src/unit_tests/document_test.py
+++ b/src/unit_tests/document_test.py
@@ -3,6 +3,7 @@ Created on Apr 13, 2015
 
 @author: szacks
 """
+
 import datetime
 import os
 import unittest
@@ -44,9 +45,7 @@ class DocumentTest(unittest.TestCase):
         self.assertIsInstance(doc, Document)
 
     def test_004_get_name(self):
-        self.doc_get1 = Document(
-            project_id=Document.default_project, doc_with_space="Testing/" + DOC_NAME
-        )
+        self.doc_get1 = Document(project_id=Document.default_project, doc_with_space="Testing/" + DOC_NAME)
         self.assertIsInstance(self.doc_get1, Document)
 
     def test_005_get_uri(self):

--- a/src/unit_tests/plan_test.py
+++ b/src/unit_tests/plan_test.py
@@ -43,9 +43,7 @@ class PlanTest(unittest.TestCase):
         * Verifies that the returned object exists and is a template
         The parent attribute is not returned
         """
-        template = Plan.create_plan_template(
-            TEMPLATE_ID, "Regression", DEFAULT_PROJ, None
-        )
+        template = Plan.create_plan_template(TEMPLATE_ID, "Regression", DEFAULT_PROJ, None)
         self.assertIsNotNone(template.plan_id)
         self.assertTrue(template.is_template)
 

--- a/src/unit_tests/revert_tests.py
+++ b/src/unit_tests/revert_tests.py
@@ -1,4 +1,5 @@
 import pysvn
+
 from pylero.project import Project
 from pylero.test_run import TestRun
 

--- a/src/unit_tests/test_run_test.py
+++ b/src/unit_tests/test_run_test.py
@@ -3,6 +3,7 @@ Created on Apr 19, 2015
 
 @author: szacks
 """
+
 import datetime
 import os
 import unittest
@@ -13,8 +14,7 @@ from pylero.test_record import TestRecord
 from pylero.test_run import TestRun
 from pylero.test_step import TestStep
 from pylero.test_step_result import TestStepResult
-from pylero.work_item import IncidentReport
-from pylero.work_item import TestCase
+from pylero.work_item import IncidentReport, TestCase
 
 DEFAULT_PROJ = TestRun.default_project
 TIME_STAMP = datetime.datetime.now().strftime("%Y%m%d%H%M%s")
@@ -78,9 +78,7 @@ class TestRunTest(unittest.TestCase):
         * Tries to create another template with an invalid kwarg
         """
         global TEMPLATE_ID
-        template = TestRun.create_template(
-            DEFAULT_PROJ, TEMPLATE_ID, "Empty", title=TEMPLATE_TITLE, arch="i386"
-        )
+        template = TestRun.create_template(DEFAULT_PROJ, TEMPLATE_ID, "Empty", title=TEMPLATE_TITLE, arch="i386")
         TEMPLATE_ID = template.test_run_id
         self.assertIsNotNone(template.test_run_id)
         self.assertTrue(template.is_template)
@@ -200,9 +198,7 @@ class TestRunTest(unittest.TestCase):
         rec = tr.records[-1]
         self.assertTrue(len(rec.attachments) == 1)
         self.assertEqual(rec.attachments[0].title, ATTACH_TITLE)
-        tr.delete_attachment_from_test_record(
-            rec.test_case_id, rec.attachments[0].filename
-        )
+        tr.delete_attachment_from_test_record(rec.test_case_id, rec.attachments[0].filename)
         tr.reload()
         rec = tr.records[-1]
         self.assertEqual(rec.attachments, [])

--- a/src/unit_tests/work_item_test.py
+++ b/src/unit_tests/work_item_test.py
@@ -3,13 +3,13 @@ Created on Apr 15, 2015
 
 @author: szacks
 """
+
 import os
 import unittest
 
 from pylero.exceptions import PyleroLibException
 from pylero.test_step import TestStep
-from pylero.work_item import Requirement
-from pylero.work_item import TestCase
+from pylero.work_item import Requirement, TestCase
 
 DEFAULT_PROJ = TestCase.default_project
 HYPERLINK = "http://www.google.com"


### PR DESCRIPTION
## Summary
- **Fixes #185**: CERT_PATH was being set after all `_SudsClientWrapper` instances were created, causing SSL certificate verification to fail. Moved SSL certificate configuration to before client creation.

## Modernization
- Replace `black` + `reorder-python-imports` with `ruff`
- Update pre-commit hooks to latest versions (pre-commit-hooks v5.0.0, ruff v0.8.4)
- Drop Python 3.8 and 3.9 support (now 3.10-3.13)
- Add `uv` configuration for dev dependencies
- Update `CONTRIBUTION.rst` with uv workflow
- Apply ruff formatting with 120 char line length

## Test plan
- [x] Verified CERT_PATH is set before WSDL client creation
- [x] Verified SSL connection works with `POLARION_CERT_PATH` env var
- [x] All pre-commit checks pass
- [x] Module imports successfully