### PR TITLE
fix: restore dynamic imports removed by ruff modernization

### DIFF
--- a/src/pylero/work_item.py
+++ b/src/pylero/work_item.py
@@ -17,7 +17,7 @@ from pylero.custom import ArrayOfCustom, Custom
 from pylero.custom_field import CustomField
 from pylero.custom_field_type import CustomFieldType
 from pylero.enum_custom_field_type import EnumCustomFieldType
-from pylero.enum_option_id import EnumOptionId
+from pylero.enum_option_id import ArrayOfEnumOptionId, EnumOptionId  # noqa: F401
 from pylero.exceptions import PyleroLibException
 from pylero.externally_linked_work_item import ArrayOfExternallyLinkedWorkItem, ExternallyLinkedWorkItem
 from pylero.hyperlink import ArrayOfHyperlink, Hyperlink
@@ -25,6 +25,7 @@ from pylero.linked_work_item import ArrayOfLinkedWorkItem, LinkedWorkItem
 from pylero.planning_constraint import ArrayOfPlanningConstraint, PlanningConstraint
 from pylero.priority_option_id import PriorityOptionId
 from pylero.project import Project
+from pylero.properties import Properties  # noqa: F401
 from pylero.revision import ArrayOfRevision, Revision
 from pylero.subterra_uri import SubterraURI
 from pylero.test_step import TestStep
@@ -35,7 +36,7 @@ from pylero.user import ArrayOfUser, User
 from pylero.work_record import ArrayOfWorkRecord, WorkRecord
 from pylero.workflow_action import WorkflowAction
 
-# ArrayOfEnumOptionId is used in dynamic code for custom fields
+# ArrayOfEnumOptionId and Properties are used in dynamic code for custom fields
 
 
 class _WorkItem(BasePolarion):


### PR DESCRIPTION
## Summary

- Restore `ArrayOfEnumOptionId` import that was accidentally removed in commit 992340c when ruff consolidated imports
- Add `Properties` import which may be needed for other custom field types
- Use `# noqa: F401` comments to prevent future removal by ruff

## Root Cause

The modernization commit 992340c ("chore: modernize tooling and drop legacy Python versions") accidentally removed the `ArrayOfEnumOptionId` import. The original `# NOQA` comment was not recognized by ruff when it consolidated imports from separate lines into one line.

This import is required for dynamic custom field type resolution in `get_custom_fields()` which uses `globals()[type_name]` to look up classes at runtime.

## Test plan

- [x] Verify custom fields with `ArrayOfEnumOptionId` type work correctly
- [x] Run existing unit tests