### PR TITLE
chore: bump version to 0.2.0 for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires_ = ["click", "suds"]
 if __name__ == "__main__":
     setup(
         name=PACKAGE_NAME,
-        version="0.1.1",
+        version="0.2.0",
         description="Python SDK for Polarion",
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
- Updates package version from 0.1.1 to 0.2.0

## Context
The PyPI publish workflow failed because `setup.py` had version "0.1.1" hardcoded, but we're releasing version 0.2.0. PyPI rejected the upload because 0.1.1 already exists.

After this PR is merged, the 0.2.0 tag and release need to be recreated to trigger a new publish.