### PR TITLE
fix(test_run): custom field type Enum: Work Item: Query register as _…

### DIFF
--- a/src/pylero/test_run.py
+++ b/src/pylero/test_run.py
@@ -424,6 +424,10 @@ class TestRun(BasePolarion):
         # some custom types have a [] segment. Still unsure of how to handle
         # those specific attributes, but for now, this will ignore them
         field_type = field_type.split("[")[0]
+        if field_type == "@WorkItems":
+            # cf type: Enum -> Work Item -> Query, such as
+            # @WorkItems[type:c_product AND status: approved AND project.id:MWE_Polarion_Testing]
+            return _WorkItem
         if field_type.startswith("@"):
             # an enum based on an object
             return [globals()[x] for x in globals() if x.lower() == field_type[1:].lower()][0]


### PR DESCRIPTION
Dear all,

i was hit with an over engineered test run template setup.

A TestRun.create( ...) greeted me with an "IndexError: list index out of range".

Pylero was able to create a Testrun in Polarion but failed right after that, which lead me into test_run.py:

_cache_custom_fields(...) -> _custom_field_types(...) 

The generated list at [test_run.py#L429](https://github.com/RedHatQE/pylero/blob/0902b411fb574a3ad3228968ef7bf69d3a8c3822/src/pylero/test_run.py#L429 ) was empty.
The comment there says we ignore certain fields, those fields seem to be handled by the split globals lookup. But it did not catch this case.

The attached screenshots show the kind of field pylero and myself stumbled over:

<img width="1521" height="678" alt="polarion_test_run_cf" src="https://github.com/user-attachments/assets/07560169-3c49-43cf-bc02-4f6f7c318422" />

<img width="1661" height="540" alt="test_run_polarion_template" src="https://github.com/user-attachments/assets/5a9b5609-03b3-49d2-a098-74a6ee97e2db" />

The "field_type" is in the nature of:
@WorkItems[type:c_product AND status:approved AND project.id:polarion_id]
->
@WorkItems["work item query"]

Since such a work item query can be all kind of work items class objects i opted to use the _Workitem class.

With this TestRun.create( ...) succeeds and the TestRun object can be operated.

I am not entirely sure that this is what should be done or if with this the generated list lookup can be dropped.

Looking into the query and checking which work item classes are returned seems to be mood, since we need a singular type?



